### PR TITLE
Delimited by fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,14 @@
 cmake_minimum_required(VERSION 3.22)  # Specify minimum CMake version
 cmake_policy(SET CMP0135 NEW)
 
-project(mparse)  # Set the project name
+set(CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+    CACHE STRING "Vcpkg toolchain")
+#set(VCPKG_TARGET_TRIPLET "arm64-osx" CACHE STRING "")
 
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+project(mparse)
 
 include(FetchContent)
 FetchContent_Declare(
@@ -14,8 +18,15 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(googletest)
 
+find_package(fmt REQUIRED)
+
 # Add an executable target
 add_executable(mparse src/main.cpp)
+
+target_link_libraries(
+  mparse
+  fmt::fmt
+)
 
 enable_testing()
 
@@ -26,6 +37,7 @@ add_executable(
 
 target_link_libraries(
   mparse_test
+  fmt::fmt
   GTest::gtest_main
   GTest::gmock_main
 )

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 This is a tiny library I wrote for fun after being tasked with writing a css parser (for a very small subset of css). I initially implemented that as a recursive decent parser but remembered back
-to some cool stuff I learned about with Haskell and Monadic parsing. And since I'm working in C++ for 
+to some cool stuff I learned about with Haskell and Monadic parsing. And since I'm working in C++ for
 part of my work project I figured I'd try to write my own little monadic parser combinator toolkit in C++ 23.
 
 ## How does this thing work?
@@ -15,9 +15,9 @@ along the way.
     // A simple example.
 
     auto parser = parse_str("hello")
-        .skip(whitespace())
+        .skip(parse_ws())
         .and_then(parse_literal(','))
-        .skip(whitespace())
+        .skip(parse_ws())
         .and_then(parse_str("world"));
 
     auto result = parser("hello, world");
@@ -32,6 +32,7 @@ along the way.
 ```
 
 ## Status
+
 This is very early experimental code. There no error reporting. There may be bugs. There aren't enough tests.
 
 More combinators may be useful, like `parse_until` or `skip_until` for comments. It is not

--- a/src/parser.h
+++ b/src/parser.h
@@ -40,9 +40,6 @@ ParseResult<T> make_parse_result(T value, std::string_view remaining) {
 
 template<typename T>
 ParseResult<T> empty_parse_result(std::string_view input, const std::string& error) {
-    if (!error.empty()) {
-//        std::cerr << error << std::endl;
-    }
     return ParseResult<T>{
         .result = std::nullopt,
         .input = input,
@@ -506,18 +503,16 @@ Parser<detail::result_vector_t<T>> parse_delimited_by(
 ) {
     using ResultType = detail::result_vector_t<T>;
     return Parser<ResultType>([=](std::string_view input) {
-        std::cout << "-> delimited_by" << std::endl;
 
         auto tokens_result = parse_some(parser.skip(delimiter))(input);
-        detail::operator<<(std::cout, tokens_result) << std::endl;
+
         if (!tokens_result) {
             return empty_parse_result<ResultType>(input, tokens_result.error);
         }
         input = tokens_result.input;
-        std::cout << "  input now: " << input << std::endl;
-//        auto last_token = parser.skip(terminator)(input);
+
         auto last_token_result = parser(input);
-        detail::operator<<(std::cout, last_token_result) << std::endl;
+
         if (!last_token_result) {
             return empty_parse_result<ResultType>(input, last_token_result.error);
         }
@@ -526,9 +521,6 @@ Parser<detail::result_vector_t<T>> parse_delimited_by(
         if (!term_result) {
             return empty_parse_result<ResultType>(term_result.input, term_result.error);
         }
-        std::cout << "  input now: " << last_token_result.input << std::endl;
-
-        std::cout << "<- delimited_by" << std::endl;
 
         auto results = tokens_result.value();
         results.push_back(last_token_result.value());

--- a/src/parser.h
+++ b/src/parser.h
@@ -1,18 +1,26 @@
 #ifndef __PARSER_H__
 #define __PARSER_H__
 
+#include <functional>
+#include <optional>
 #include <string>
 #include <string_view>
-#include <optional>
-#include <functional>
 #include <vector>
+#include <iostream>
+
+#include <fmt/format.h>
 
 using unit = std::monostate;
+
+template<class T>
+class Parser;
 template <class T>
 struct ParseResult
 {
+    // Maybe result should be std::expect?
     std::optional<T> result;
     std::string_view input;
+    std::string error;
 
     operator bool() const { return result.has_value(); }
     bool operator!() const { return !result.has_value(); }
@@ -31,12 +39,86 @@ ParseResult<T> make_parse_result(T value, std::string_view remaining) {
 }
 
 template<typename T>
-ParseResult<T> empty_parse_result(std::string_view input) {
+ParseResult<T> empty_parse_result(std::string_view input, const std::string& error) {
+    if (!error.empty()) {
+//        std::cerr << error << std::endl;
+    }
     return ParseResult<T>{
         .result = std::nullopt,
-        .input = input
+        .input = input,
+        .error = error
     };
 }
+
+namespace detail {
+    template<typename T>
+    struct parser_impl {
+        template<typename U>
+        static auto skip(const Parser<T>& parser, const Parser<U>& next) {
+            return Parser<T>([parser, next](std::string_view input) {
+                auto result = parser(input);
+                if (!result) {
+                    return empty_parse_result<T>(input, result.error);
+                }
+                auto next_result = next(result.input);
+                if (!next_result) {
+                    return empty_parse_result<T>(result.input, next_result.error);
+                }
+                return make_parse_result(
+                    result.value(),
+                    next_result.input
+                );
+            });
+        }
+    };
+
+    struct discontinuous_tag {};
+    struct discontinuous_string_view : std::string_view, discontinuous_tag {
+        discontinuous_string_view(const std::string_view& other) 
+            : std::string_view(other) {}
+        discontinuous_string_view& operator=(const std::string_view& other) {
+            std::string_view::operator=(other);
+            return *this;
+        }        
+    };
+
+    template<typename T>
+    using result_vector_t = std::conditional_t<
+        std::is_same_v<T, std::string_view>,
+        std::vector<discontinuous_string_view>,
+        std::vector<T>
+    >;
+
+
+    template<class T>
+    std::ostream& operator<<(std::ostream& out, const std::vector<T>& xs) {
+        out << "[";
+        for (auto it = xs.begin(); it != xs.end(); ++it) {
+            out << *it;
+            if (it + 1 != xs.end()) {
+                out << ",";
+            }
+        }
+        out << "]";
+        return out;
+    }
+
+    std::ostream& operator<<(std::ostream& out, const unit _) {
+        out << "unit";
+        return out;
+    }
+
+    template<class T>
+    std::ostream& operator<<(std::ostream& out, const ParseResult<T>& res) {
+        if (res) {
+            out << res.value();
+        } else {
+            out << res.error;
+        }
+        return out;
+    }
+}
+
 template <class T>
 class Parser
 {
@@ -74,7 +156,7 @@ public:
         return Parser<U>([self, fn](std::string_view input) {
             auto result = self(input);
             if (!result) {
-                return empty_parse_result<U>(input);
+                return empty_parse_result<U>(input, result.error);
             }
             ReturnParser then_parser = fn(result.value());
             return then_parser(result.input);
@@ -87,7 +169,7 @@ public:
         return Parser<U>([self, next](std::string_view input) {
             auto result = self(input);
             if (!result) {
-                return empty_parse_result<U>(input);
+                return empty_parse_result<U>(input, result.error);
             }
             return next(result.input);
         });
@@ -99,11 +181,14 @@ public:
         return Parser<T>([self, next](std::string_view input) {
             auto result = self(input);
             if (!result) {
-                return empty_parse_result<T>(input);
+                return empty_parse_result<T>(input, result.error);
             }
             auto next_result = next(result.input);
             if (next_result) {
-                return empty_parse_result<T>(input);
+                return empty_parse_result<T>(
+                    input,
+                    fmt::format("Expected failure but parsed {}", next_result.value())
+                );
             }
             return result;
         });
@@ -111,22 +196,8 @@ public:
 
     template<typename U>
     auto skip(const Parser<U>& next) const {
-        Parser self = parse_;
-        return Parser<T>([self, next](std::string_view input) {
-            auto result = self(input);
-            if (!result) {
-                return empty_parse_result<T>(input);
-            }
-            auto next_result = next(result.input);
-            if (!next_result) {
-                return empty_parse_result<T>(result.input);
-            }
-            return make_parse_result(
-                result.value(),
-                next_result.input
-            );
-        });
-    }
+        return detail::parser_impl<T>::skip(*this, next);
+    }    
 
     template<typename F>
     auto transform(F&& fn) const {
@@ -135,7 +206,7 @@ public:
         return Parser<U>([self, fn](std::string_view input) {
             auto result = self(input);
             if (!result) {
-                return empty_parse_result<U>(input);
+                return empty_parse_result<U>(input, result.error);
             }
             return make_parse_result<U>(
                 fn(result.value()),
@@ -156,10 +227,31 @@ private:
 
 using StringParser = Parser<std::string_view>;
 
+namespace detail {
+template<>
+struct parser_impl<std::string_view> {
+    // When skipping over input the result becomes discontinuous
+    template<typename U>
+    static auto skip(const StringParser& parser, const Parser<U>& next) {
+        Parser<detail::discontinuous_string_view> to_dc = parser.transform([](auto value) {
+            return detail::discontinuous_string_view(value);
+        });
+        return to_dc.skip(next);
+    }
+};
+
+Parser<detail::discontinuous_string_view> to_discontinuous(StringParser parser) {
+    return parser.transform([](auto value) {
+        return detail::discontinuous_string_view(value);
+    });
+}
+
+}
+
 template<typename T>
 Parser<T> parse_never() {
     return Parser<T>([](std::string_view input) {
-        return empty_parse_result<T>(input);
+        return empty_parse_result<T>(input, "Error: never");
     });
 }
 
@@ -183,7 +275,10 @@ namespace detail {
                     );
                 }
             }
-            return empty_parse_result<std::string_view>(input);
+            return empty_parse_result<std::string_view>(
+                input,
+                fmt::format("Error: unexpected char {}", input.front())
+            );
         });
     }
     
@@ -204,7 +299,9 @@ StringParser parse_literal(char ch)
             return make_parse_result(input.substr(0, 1),
                 input.substr(1));
         } else {
-            return empty_parse_result<std::string_view>(input);
+            return empty_parse_result<std::string_view>(
+                input,
+                fmt::format("Expected {} but saw {}", ch, input.front()));
         }
     });
 }
@@ -219,7 +316,9 @@ StringParser parse_range(char first, char last)
                     input.substr(1));
             }
         }
-        return empty_parse_result<std::string_view>(input);
+        return empty_parse_result<std::string_view>(
+            input,
+            fmt::format("Error: expected [{}-{}] but saw {}", first, last, input.front()));
     });
 }
 
@@ -232,7 +331,10 @@ StringParser parse_str(std::string_view str)
                 input.substr(str.size())
             );
         } else {
-            return empty_parse_result<std::string_view>(input);
+            return empty_parse_result<std::string_view>(
+                input,
+                fmt::format("Error: expected {} but saw {}", str, input)
+            );
         } 
     });
 }
@@ -242,7 +344,9 @@ StringParser parse_any_of(std::string_view str)
 {
     return StringParser([str](std::string_view input){
         if (!detail::str_contains(str, input.front())) {
-            return empty_parse_result<std::string_view>(input);
+            return empty_parse_result<std::string_view>(
+                input,
+            fmt::format("Error: expected any of {} but saw {}", str, input.front()));
         }
         return make_parse_result(input.substr(0, 1), input.substr(1));
     });
@@ -260,7 +364,10 @@ Parser<int> parse_digit(int first = 0, int last = 9)
                 }
             }
         }
-        return empty_parse_result<int>(input);
+        return empty_parse_result<int>(
+            input,
+            fmt::format("Error: expected digit from [{} - {}] but saw {}", first, last, input.front())
+        );
     });
 }
 
@@ -272,7 +379,6 @@ Parser<std::vector<T>> parse_some(Parser<T> parser)
         while (!input.empty()) {
             auto result = parser(input);
             if (!result) {
-                //std::cerr << "did not parse " << input << std::endl;
                 break;
             }
             results.push_back(result.value());
@@ -290,9 +396,11 @@ Parser<std::vector<T>> parse_n(Parser<T> parser, int min, std::optional<int> max
         int count = 0;
         int count_max = max.value_or(min);
 
+        std::string error;
         while (!input.empty() && count < count_max) {
             auto result = parser(input);
             if (!result) {
+                error = result.error;
                 break;
             }
             results.push_back(result.value());
@@ -301,7 +409,12 @@ Parser<std::vector<T>> parse_n(Parser<T> parser, int min, std::optional<int> max
             ++count;
         }
         if (count < min) {
-            return empty_parse_result<std::vector<T>>(input);
+            return empty_parse_result<std::vector<T>>(
+                input,
+                fmt::format(
+                    "Error: expected to match {} times but saw {}\n\tInner: {}",
+                        min, count, error)
+            );
         }
         return make_parse_result(results, input);
     });
@@ -334,9 +447,11 @@ StringParser parse_n(StringParser parser, int min, std::optional<int> max = std:
         int count_max = max.value_or(min);
         size_t pos = 0;
         std::string_view inp = input;
+        std::string error;
         while (!inp.empty() && count < count_max) {
             auto result = parser(inp);
             if (!result) {
+                error = result.error;
                 break;
             }
             pos += result.value().size();
@@ -344,7 +459,13 @@ StringParser parse_n(StringParser parser, int min, std::optional<int> max = std:
             ++count;
         }
         if (count < min) {
-            return empty_parse_result<std::string_view>(inp);
+            return empty_parse_result<std::string_view>(
+                inp,
+                fmt::format(
+                    "Error: expected {} occurences but only saw {}\n\tInner: {}",
+                    min, count, error)
+
+            );
         }
         return make_parse_result(input.substr(0, pos), inp);
     });
@@ -357,7 +478,10 @@ StringParser parse_sequence(std::initializer_list<StringParser> parsers) {
         std::string_view inp = input;
         for (auto parser: ps) {
             if (input.empty()) {
-                return empty_parse_result<std::string_view>(inp);
+                return empty_parse_result<std::string_view>(
+                    inp,
+                    fmt::format("Error: reached end of input.")
+                );
             }
             auto result = parser(inp);
             if (!result) {
@@ -374,47 +498,42 @@ StringParser parse_sequence(std::initializer_list<StringParser> parsers) {
 }
 
 template<typename T, typename D, typename S>
-Parser<std::vector<T>> parse_delimited_by(
+Parser<detail::result_vector_t<T>> parse_delimited_by(
     Parser<T> parser,
     Parser<D> delimiter,
     Parser<S> terminator,
-//    std::string_view terminator,
     std::optional<int> max = std::nullopt
 ) {
-    return Parser<std::vector<T>>([=](std::string_view input) {
-        std::vector<T> results;
+    using ResultType = detail::result_vector_t<T>;
+    return Parser<ResultType>([=](std::string_view input) {
+        std::cout << "-> delimited_by" << std::endl;
 
-//        auto parse_delim = parse_any_of(delimiter);
-        auto parse_term = terminator; //parse_any_of(terminator);
-        int times = 10;
-
-        while(!input.empty()) {
-            if (parse_term(input)) {
-                break;
-            }
-
-            bool valid = false;
-            auto item = parser(input);
-            if (item) {
-                results.emplace_back(std::move(item.value()));
-                input = item.input;
-                valid = true;
-            }
-            auto delim_result = delimiter(input);
-            if (delim_result) {
-                input = delim_result.input;
-                valid = true;
-            }
-
-            if (!valid) {
-                return empty_parse_result<std::vector<T>>(input);
-            }
-
-            if (--times == 0) {
-                break;
-            }
+        auto tokens_result = parse_some(parser.skip(delimiter))(input);
+        detail::operator<<(std::cout, tokens_result) << std::endl;
+        if (!tokens_result) {
+            return empty_parse_result<ResultType>(input, tokens_result.error);
         }
-        return make_parse_result(results, input);
+        input = tokens_result.input;
+        std::cout << "  input now: " << input << std::endl;
+//        auto last_token = parser.skip(terminator)(input);
+        auto last_token_result = parser(input);
+        detail::operator<<(std::cout, last_token_result) << std::endl;
+        if (!last_token_result) {
+            return empty_parse_result<ResultType>(input, last_token_result.error);
+        }
+        // now expect the terminator
+        auto term_result = terminator(last_token_result.input);
+        if (!term_result) {
+            return empty_parse_result<ResultType>(term_result.input, term_result.error);
+        }
+        std::cout << "  input now: " << last_token_result.input << std::endl;
+
+        std::cout << "<- delimited_by" << std::endl;
+
+        auto results = tokens_result.value();
+        results.push_back(last_token_result.value());
+
+        return make_parse_result(results, last_token_result.input);
     });
 }
 
@@ -426,13 +545,37 @@ StringParser parse_alnum() {
     return detail::parse_char_class([] (char ch) { return std::isalnum(ch); } );
 }
 
-Parser<unit> whitespace() {
-    return Parser<unit>([] (std::string_view input) {
+Parser<unit> parse_ws(bool optional = true) {
+    return Parser<unit>([optional] (std::string_view input) {
+        bool saw_ws = false;
         while (!input.empty() && (std::isblank(input.front()) || input.front() == '\n')) {
             input.remove_prefix(1);
+            saw_ws = true;
+        }
+        if (!optional && !saw_ws) {
+            return empty_parse_result<unit>(input, "Error: failed to parse whitespace");
         }
         return make_parse_result(unit{}, input);
     });
+}
+
+template<typename T, typename U>
+Parser<T> parse_ignoring(Parser<T> parser, Parser<U> ignore) {
+    return parser.skip(ignore).or_else(ignore.and_then(parser).skip(ignore));
+}
+
+template<typename U>
+Parser<detail::discontinuous_string_view> parse_ignoring(StringParser parser, Parser<U> ignore) {
+    return parse_ignoring(detail::to_discontinuous(parser), ignore);
+}
+
+template<typename T>
+Parser<T> parse_ignoring_ws(Parser<T> parser) {
+    return parse_ignoring(parser, parse_ws());
+}
+
+Parser<detail::discontinuous_string_view> parse_ignoring_ws(StringParser parser) {
+    return parse_ignoring(parser, parse_ws());
 }
 
 template <typename T>

--- a/src/style_sheet.h
+++ b/src/style_sheet.h
@@ -1,0 +1,53 @@
+#ifndef __STYLE_SHEET_H__
+#define __STYLE_SHEET_H__
+
+#include <string>
+#include <string_view>
+#include <iostream>
+#include <unordered_map>
+
+struct Dimension
+{
+    int value;
+    enum
+    {
+        pct,
+        px,
+    } units;
+};
+
+std::ostream& operator <<(std::ostream& out, const Dimension& dim) {
+    out << dim.value << (dim.units == Dimension::px ? "px" : "pct");
+    return out;
+}
+struct Color {
+    int r;
+    int g;
+    int b;
+};
+
+std::ostream& operator <<(std::ostream& out, const Color& c) {
+    out << "rgb(" << c.r << "," << c.g << "," << c.b << ")";
+    return out;
+}
+
+struct Spacing {
+    Dimension top;
+    Dimension right;
+    Dimension bottom;
+    Dimension left;
+};
+
+std::ostream& operator <<(std::ostream& out, const Spacing& s) {
+    out << s.top << "," << s.right << "," << s.bottom << "," << s.left;
+    return out;
+}
+struct Rule {
+    std::string property;
+    std::variant<int, std::string, Dimension, Color, Spacing> value;
+};
+struct StyleSheet {
+    std::unordered_map<std::string, std::vector<Rule>> selectors;
+};
+
+#endif  // __STYLE_SHEET_H__

--- a/src/test/mparse_test.cpp
+++ b/src/test/mparse_test.cpp
@@ -2,76 +2,123 @@
 #include <gmock/gmock.h>
 
 #include "../parser.h"
+#include "../style_sheet.h"
 
-#define EXPECT_STRV_EQ(s1, s2) \
-    do { std::string s1s(s1); std::string s2s(s2); EXPECT_STREQ(s1s.c_str(), s2s.c_str()); } while(0)
+using ::testing::ElementsAre;
+using ::testing::Eq;
 
-namespace parsers {
+template <typename T>
+void dump_result(const std::vector<T> &res)
+{
+    std::cout << "[";
+    for (auto it = res.begin(); it != res.end(); ++it)
+    {
+        std::cout << *it;
+        if ((it + 1) != res.end())
+        {
+            std::cout << ",";
+        }
+    }
+    std::cout << "]";
+}
+namespace parsers
+{
     auto hexit = parse_range('A', 'F')
-            .transform([](auto sv) { return static_cast<int>(10 + (sv.front() - 'A')); })
-            .or_else(
-                parse_range('a', 'f')
-                .transform([](auto sv) { return static_cast<int>(10 + (sv.front() - 'a')); }))
-            .or_else(
-                parse_range('0', '9')
-                .transform([](auto sv) { return static_cast<int>(sv.front() - '0'); }));
+                     .transform([](auto sv)
+                                { return static_cast<int>(10 + (sv.front() - 'A')); })
+                     .or_else(
+                         parse_range('a', 'f')
+                             .transform([](auto sv)
+                                        { return static_cast<int>(10 + (sv.front() - 'a')); }))
+                     .or_else(
+                         parse_range('0', '9')
+                             .transform([](auto sv)
+                                        { return static_cast<int>(sv.front() - '0'); }));
 
-    auto hexbyte = parse_n(hexit, 1, 2).transform([] (auto hexs) {
+    auto hexbyte = parse_n(hexit, 1, 2).transform([](auto hexs)
+                                                  {
         int val = 0;
         for (auto h : hexs) {
             val = (val << 4) + h;
         }
-        return val;
-    });    
+        return val; });
+
+    Parser<int> number()
+    {
+        auto positive_number = parse_digit(1, 9).and_then([](int val)
+                                                          { return parse_some(parse_digit()).transform([val](std::vector<int> digits)
+                                                                                                       {
+                int result = val;
+                for (auto d : digits) {
+                    result = (result * 10) + d;
+                }
+                return result; }); });
+
+        auto zero = parse_digit(0, 0).and_not(parse_digit(0, 9));
+
+        auto integer = positive_number
+                           .or_else(zero)
+                           .or_else(
+                               parse_literal('-')
+                                   .and_then(positive_number)
+                                   .transform([](int val)
+                                              { return -val; }));
+        return integer;
+    }
 }
 // Demonstrate some basic assertions.
-TEST(ParserTest, ParseStringTest) {
-  auto parser = parse_str("hello");
-  auto result = parser("hello");
+TEST(ParserTest, ParseStringTest)
+{
+    auto parser = parse_str("hello");
+    auto result = parser("hello");
 
-  EXPECT_TRUE(result.has_value());
-  // can't use string view??
-//  std::string x(result.value());
-  EXPECT_STRV_EQ(result.value(), "hello");
+    EXPECT_TRUE(result.has_value());
+    EXPECT_THAT(result.value(), Eq("hello"));
 }
 
-TEST(ParserText, ParseHelloWorld) {
+TEST(ParserText, ParseHelloWorld)
+{
 
     auto parser = parse_str("hello")
-        .skip(whitespace())
-        .and_then(parse_str(","))
-        .skip(whitespace())
-        .and_then(parse_str("world"));
+                      .skip(parse_ws())
+                      .and_then(parse_str(","))
+                      .skip(parse_ws())
+                      .and_then(parse_str("world"));
 
     auto result = parser("hello, world");
     assert(result.value() == "world");
 
-    EXPECT_THAT(result.value(), ::testing::Eq("world"));
+    EXPECT_THAT(result.value(), Eq("world"));
 }
 
-TEST(ParserTest, ContainsStr) {
+TEST(ParserTest, ContainsStr)
+{
     EXPECT_TRUE(detail::str_contains("hello", 'h'));
     EXPECT_FALSE(detail::str_contains("hello", 'x'));
 }
 
-TEST(ParserTest, HexNumbers) {
-    auto lowercase = {"a", "b", "c", "d", "e", "f" };
+TEST(ParserTest, HexNumbers)
+{
+    auto lowercase = {"a", "b", "c", "d", "e", "f"};
     int expected = 10;
-    for (auto input : lowercase) {
+    for (auto input : lowercase)
+    {
         EXPECT_EQ(parsers::hexit(input).value(), expected);
         ++expected;
     }
 
-    auto uppercase = {"A", "B", "C", "D", "E", "F" };
+    auto uppercase = {"A", "B", "C", "D", "E", "F"};
     expected = 10;
-    for (auto input : uppercase) {
+    for (auto input : uppercase)
+    {
         EXPECT_EQ(parsers::hexit(input).value(), expected);
         ++expected;
     }
 
     auto digits = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"};
     expected = 0;
-    for (auto input : digits) {
+    for (auto input : digits)
+    {
         EXPECT_EQ(parsers::hexit(input).value(), expected);
         ++expected;
     }
@@ -88,27 +135,10 @@ TEST(ParserTest, HexNumbers) {
     EXPECT_FALSE(parsers::hexbyte("-1"));
 }
 
-TEST(ParserTest, ParseNumber) {
+TEST(ParserTest, ParseNumber)
+{
     // These are complicated enough that they should probably go in the library
-    auto positive_number = parse_digit(1, 9).and_then([] (int val) {
-        return parse_some(parse_digit()).transform([val] (std::vector<int> digits) {
-            int result = val;
-            for (auto d : digits) {
-                result = (result * 10) + d;
-            }
-            return result;
-        });
-    });
-
-    auto zero = parse_digit(0, 0).and_not(parse_digit(0, 9));
-
-    auto integer = positive_number
-        .or_else(zero)
-        .or_else(
-            parse_literal('-')
-            .and_then(positive_number)
-            .transform([] (int val) { return -val; })
-        );
+    auto integer = parsers::number();
 
     EXPECT_EQ(integer("0").value(), 0);
     EXPECT_EQ(integer("123").value(), 123);
@@ -117,59 +147,73 @@ TEST(ParserTest, ParseNumber) {
     EXPECT_FALSE(integer("-0"));
 }
 
-TEST(ParserTest, DelimitedBy) {
-    auto token_parser = parse_n(parse_any_of("abcd"),1,2);
+TEST(ParserTest, DelimitedBy)
+{
+    auto token_parser = parse_n(parse_any_of("abcd"), 1, 2);
     auto parser = parse_delimited_by(
         token_parser, parse_literal(','), parse_literal(';'));
 
     auto result = parser("a,bc,d;");
-    EXPECT_TRUE(result);
-    EXPECT_STRV_EQ(result.value()[0], "a");
-    EXPECT_STRV_EQ(result.value()[1], "bc");
-    EXPECT_STRV_EQ(result.value()[2], "d");
+    ASSERT_TRUE(result);
+    EXPECT_THAT(result.value(), ElementsAre("a", "bc", "d"));
     EXPECT_EQ(result.input.front(), ';');
 }
 
-TEST(ParserTest, DelimitedByMultiple) {
-    auto token_parser = parse_n(parse_any_of("abcde"),1,20);
-    auto parser = parse_delimited_by(
-        token_parser, parse_any_of(", "), parse_literal(';'));
+TEST(ParserTest, DelimitedByMultiple)
+{
+    auto token = parse_some(parse_any_of("abcde"));
+    auto delimiter = parse_ignoring_ws(parse_literal(','));
+    auto terminator = parse_literal(';');
 
-    auto result = parser("a ,bc, d,e ;");
-    EXPECT_TRUE(result);
-    EXPECT_STRV_EQ(result.value()[0], "a");
-    EXPECT_STRV_EQ(result.value()[1], "bc");
-    EXPECT_STRV_EQ(result.value()[2], "d");
-    EXPECT_STRV_EQ(result.value()[3], "e");
+    auto parser = parse_delimited_by(token, delimiter, terminator);
+
+    auto result = parser("a ,bc, d,e;");
+    ASSERT_TRUE(result);
+    EXPECT_THAT(result.value(),
+                ElementsAre("a", "bc", "d", "e"));
 }
 
-TEST(ParserTest, AnyOf) {
+// TEST(ParserTest, DelimitedByMultiple) {
+//     auto token_parser = parse_n(parse_any_of("abcde"),1,20).skip(parse_ws());
+//     auto delimiter = parse_literal(',').skip(parse_ws());
+//     auto parser = parse_delimited_by(
+//         token_parser, delimiter, parse_literal(';'));
+
+//     auto result = parser("a ,bc, d,e;");
+//     ASSERT_TRUE(result);
+//     EXPECT_THAT(result.value(),
+//         ElementsAre("a", "bc", "d", "e"));
+// }
+
+TEST(ParserTest, AnyOf)
+{
     auto parser = parse_any_of("abc&!");
 
     auto some = parse_some(parser);
     auto result = some("!!cb&baa");
 
     EXPECT_TRUE(result);
-    EXPECT_STRV_EQ(result.value(), "!!cb&baa");
+    EXPECT_THAT(result.value(), Eq("!!cb&baa"));
 }
 
-TEST(ParserTest, ParseN) {
+TEST(ParserTest, ParseN)
+{
     auto parser = parse_n(parse_any_of("abc"), 1, 2);
     auto result = parser("ab");
 
     EXPECT_TRUE(result);
-    EXPECT_STRV_EQ(result.value(), "ab");
+    EXPECT_THAT(result.value(), Eq("ab"));
 
     result = parser("bd");
     EXPECT_TRUE(result);
-    //EXPECT_STRV_EQ(result.value(), "b");
+    // EXPECT_STRV_EQ(result.value(), "b");
     EXPECT_EQ(result.input.front(), 'd');
 }
 
-TEST(ParserTest, AndNot) {
+TEST(ParserTest, AndNot)
+{
     auto parser = parse_n(
-        parse_range('a', 'z').and_not(parse_literal('x')), 4
-    );
+        parse_range('a', 'z').and_not(parse_literal('x')), 4);
 
     auto result = parser("abyz");
     ASSERT_TRUE(result);
@@ -178,18 +222,66 @@ TEST(ParserTest, AndNot) {
     ASSERT_FALSE(result);
 }
 
-TEST(ParserTest, RGB) {
+TEST(ParserTest, RGB)
+{
     auto hex = parse_str("0x").and_then(parsers::hexbyte);
-    auto delimiter = parse_any_of(", ");
+    auto delimiter = parse_ignoring_ws(parse_literal(','));
     auto parser = parse_str("rgb")
-        .skip(whitespace())
-        .and_then(parse_literal('('))
-        .and_then(
-            parse_delimited_by(hex, delimiter, parse_literal(')')))
-        .skip(parse_literal(')'));
+                      .skip(parse_ws(true))
+                      .and_then(parse_literal('('))
+                      .and_then(
+                          parse_delimited_by(hex, delimiter, parse_literal(')')))
+                      .skip(parse_literal(')'));
 
     auto result = parser("rgb(0xFF, 0xA0, 0x45)");
     EXPECT_TRUE(result);
     EXPECT_EQ(result.value().size(), 3);
-    EXPECT_THAT(result.value(), ::testing::ElementsAre(0xFF, 0xA0, 0x45));
+    EXPECT_THAT(result.value(), ElementsAre(0xFF, 0xA0, 0x45));
+    EXPECT_TRUE(result.input.empty());
+}
+
+TEST(ParserTest, Spacing)
+{
+
+    auto dimension_parser = parsers::number().and_then([](auto value) { 
+        return parse_str("px").as(Dimension{
+            .value = value,
+            .units = Dimension::px
+        })
+        .or_else(parse_literal('%').as(Dimension{
+            .value = value,
+            .units = Dimension::pct
+        })); 
+    });
+
+    auto spacing =
+        parse_delimited_by(dimension_parser, parse_ws(false), parse_literal(';'))
+            .transform([](const std::vector<Dimension> &values) -> Spacing {
+            Spacing sp;
+            dump_result(values);
+            std::cout << std::endl;
+            switch (values.size()) {
+                case 1:
+                    sp.top = sp.right = sp.bottom = sp.left = values[0];
+                    return sp;
+                case 2:
+                    sp.top = sp.bottom = values[0];
+                    sp.right = sp.left = values[1];
+                    return sp;
+                case 3:
+                    sp.top = values[0];
+                    sp.left = sp.right  = values[1];
+                    sp.bottom = values[2];
+                    return sp;
+                case 4:
+                    sp.top = values[0];
+                    sp.right = values[1];
+                    sp.bottom = values[2];
+                    sp.left = values[3];
+                    return sp;
+            }
+            return sp; });
+    auto result = spacing("10px 22px;");
+    ASSERT_TRUE(result);
+    EXPECT_TRUE(result.value().top.value == 10);
 }

--- a/styles.css
+++ b/styles.css
@@ -1,11 +1,12 @@
-something { 
-    height : 10px;
-    width : 200px;
-    color : #004488;
-}
-
 .otherthing {
     height : 20px;
     width :  201px;
     color : rgb(156, 39, 188);
+}
+
+.something {
+    height : 10px;
+    width : 200px;
+    color : #004488;
+    padding: 10px 20px;
 }


### PR DESCRIPTION
Some major re-work to address #2

- when a parse operator would produce a discontinuous string_view it is converted to a parser that chunks string_views into a list instead of returning a string_view. The latter is a kind of optimization that is nice for continuous parsing (for example a sequence of matching chars). But when a skip is inserted it requires a "discontinuous" string_view.
- started wiring up some error reporting
- handling of whitespace is wonky currently. Sometimes you want to skip and ignore it but sometimes you want to match against it, for example in a `parse_delimted_by parse`. Will address this shortly.

Also:
- demo app adds support for spacing values in css like padding or margin.
