### PR TITLE
Better whitespace handling, refactor parse_some, parse_n and friends

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,56 @@
+# Use the Google style in this project.
+BasedOnStyle: Google
+
+# Some folks prefer to write "int& foo" while others prefer "int &foo".  The
+# Google Style Guide only asks for consistency within a project, we chose
+# "int& foo" for this project:
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+# The Google Style Guide only asks for consistency w.r.t. "east const" vs.
+# "const west" alignment of cv-qualifiers. In this project we use "east const".
+QualifierAlignment: Right
+
+IncludeBlocks: Merge
+IncludeCategories:
+- Regex: '^\"google/cloud/internal/disable_deprecation_warnings.inc\"$'
+  Priority: -1
+# System and C-language headers should go last. These expressions may miss a few
+# cases, we can always add more.  Or we can conservative
+- Regex: '^<[A-Za-z0-9_]*\.h>$'
+  Priority: 10000
+- Regex: '^<sys/[A-Za-z0-9_]*\.h>$'
+  Priority: 10000
+# Matches common headers first, but sorts them after project includes
+- Regex: '^\"google/cloud/(internal/|grpc_utils/|testing_util/|[^/]+\.h)'
+  Priority: 1000
+- Regex: '^\"google/cloud/'  # project includes should sort first
+  Priority: 500
+- Regex: '^\"generator/'     # project includes should sort first
+  Priority: 500
+- Regex: '^\"generator/internal/' # project internals second
+  Priority: 1000
+- Regex: '^\"generator/testing/'  # testing helpers third
+  Priority: 1100
+- Regex: '^\"'         # And then includes from other projects or the system
+  Priority: 1500
+- Regex: '^<grpc/'
+  Priority: 2000
+- Regex: '^<google/*'
+  Priority: 3000
+- Regex: '^<.*/.*'
+  Priority: 4000
+- Regex: '^<.*.hpp>'
+  Priority: 4000
+- Regex: '^<[^/]*>'
+  Priority: 5000
+
+# Format raw string literals with a `pb` or `proto` tag as proto.
+RawStringFormats:
+- Language: TextProto
+  Delimiters:
+  - 'pb'
+  - 'proto'
+  BasedOnStyle: Google
+
+CommentPragmas: '(@copydoc|@copybrief|@see|@overload|@snippet)'

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ along the way.
     // A simple example.
 
     auto parser = parse_str("hello")
-        .skip(parse_ws())
+        .skip(parse_opt_ws())
         .and_then(parse_literal(','))
-        .skip(parse_ws())
+        .skip(parse_opt_ws())
         .and_then(parse_str("world"));
 
     auto result = parser("hello, world");
@@ -31,13 +31,27 @@ along the way.
 
 ```
 
+### Handling whitespace
+
+Sometimes you want to ignore whitespace and sometimes you don't. For example, in the
+stylesheet example we can ignore blank lines and spaces around delimiters like `'{'`, etc. but
+for some property values whitespace becomes an important delimiter like in padding.
+
+To deal with this the library has different ways to express parsing whitespace. Use
+
+`parse_ws()` - When failing to find whitespace would be a parse error
+
+`parse_opt_ws()` - When whitespace is optional.
+
+`parse_ignoring_ws()` - to wrap a parser with optional whitespace on either end of it.
+
 ## Status
 
-This is very early experimental code. There no error reporting. There may be bugs. There aren't enough tests.
+This is very early experimental code. There minimal error reporting. There may be bugs. There aren't enough tests. There will be breaking changes.
 
 More combinators may be useful, like `parse_until` or `skip_until` for comments. It is not
 hard to come up with more and build them out of the
 existing parsers.
 
-Input now is assumed to be in a single buffer and accessed via string_piece. It is a great abstraction for hadling parsing but I will have to extend this to
-handle buffering of larger input streams.
+Input now is assumed to be in a single buffer and accessed via string_view. It is a great abstraction for hadling parsing but input will likely need to be enhanced to handler large input streams.
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,281 +1,252 @@
-#include <iostream>
-#include <iomanip>
-#include <string>
-#include <sstream>
-#include <fstream>
-#include <vector>
-#include <variant>
-#include <cstdarg>
-#include <optional>
-#include <charconv>
-#include <system_error>
-
 #include "parser.h"
 #include "style_sheet.h"
+#include <charconv>
+#include <cstdarg>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <system_error>
+#include <variant>
+#include <vector>
 
 // A parser for things
 // is a function from strings
 // to lists of pairs of strings and things.
 
-template<typename T>
-void dump_result(const std::vector<T> &res)
-{
-    std::cout << "[";
-    for (auto it = res.begin(); it != res.end(); ++it)
-    {
-        std::cout << *it;
-        if ((it + 1) != res.end())
-        {
-            std::cout << ",";
-        }
+template <typename T>
+void dump_result(std::vector<T> const& res) {
+  std::cout << "[";
+  for (auto it = res.begin(); it != res.end(); ++it) {
+    std::cout << *it;
+    if ((it + 1) != res.end()) {
+      std::cout << ",";
     }
-    std::cout << "]";
+  }
+  std::cout << "]";
 }
 
 Parser<int> parse_number() {
-    auto positive_number = parse_digit(1, 9).and_then([] (int val) {
-        return parse_some(parse_digit()).transform([val] (std::vector<int> digits) {
-            int result = val;
-            for (auto d : digits) {
-                result = (result * 10) + d;
-            }
-            return result;
-        });
+  auto positive_number = parse_digit(1, 9).and_then([](int val) {
+    return parse_some(parse_digit()).transform([val](std::vector<int> digits) {
+      int result = val;
+      for (auto d : digits) {
+        result = (result * 10) + d;
+      }
+      return result;
     });
+  });
 
-    auto zero = parse_digit(0, 0).and_not(parse_digit(0, 9));
+  auto zero = parse_digit(0, 0).and_not(parse_digit(0, 9));
 
-    return positive_number
-        .or_else(zero)
-        .or_else(
-            parse_literal('-')
-            .and_then(positive_number)
-            .transform([] (int val) { return -val; })
-        );
+  return positive_number.or_else(zero).or_else(
+      parse_literal('-').and_then(positive_number).transform([](int val) {
+        return -val;
+      }));
 }
 
 // For style sheet - esque sample.
 
-Parser<Dimension> parse_dimension()
-{
-    auto dimension_parser = parse_number().and_then([](auto value) {
-        return parse_str("px").as(Dimension {
-                .value = value,
-                .units = Dimension::px
-        }).or_else(parse_literal('%').as(Dimension {
-                .value = value,
-                .units = Dimension::pct
-        }));
-    });
-    return dimension_parser;
+Parser<Dimension> parse_dimension() {
+  auto dimension_parser = parse_number().and_then([](auto value) {
+    return parse_str("px")
+        .as(Dimension{.value = value, .units = Dimension::px})
+        .or_else(parse_literal('%').as(
+            Dimension{.value = value, .units = Dimension::pct}));
+  });
+  return dimension_parser;
 }
 
-Parser<Spacing> parse_spacing()
-{
-    auto spacing =
-        parse_delimited_by(parse_dimension(), parse_ws(true), parse_literal(';'))
-        .transform([] (const std::vector<Dimension>& values) -> Spacing {
+Parser<Spacing> parse_spacing() {
+  auto spacing =
+      parse_delimited_by(parse_dimension(), parse_ws(), parse_literal(';'))
+          .transform([](std::vector<Dimension> const& values) -> Spacing {
             Spacing sp;
-            dump_result(values);
-            std::cout << std::endl;
             switch (values.size()) {
-                case 1:
-                    sp.top = sp.right = sp.bottom = sp.left = values[0];
-                    return sp;
-                case 2:
-                    sp.top = sp.bottom = values[0];
-                    sp.right = sp.left = values[1];
-                    return sp;
-                case 3:
-                    sp.top = values[0];
-                    sp.left = sp.right  = values[1];
-                    sp.bottom = values[2];
-                    return sp;
-                case 4:
-                    sp.top = values[0];
-                    sp.right = values[1];
-                    sp.bottom = values[2];
-                    sp.left = values[3];
-                    return sp;
+              case 1:
+                sp.top = sp.right = sp.bottom = sp.left = values[0];
+                return sp;
+              case 2:
+                std::cout << "spacing " << sp << std::endl;
+                sp.top = sp.bottom = values[0];
+                sp.right = sp.left = values[1];
+                return sp;
+              case 3:
+                sp.top = values[0];
+                sp.left = sp.right = values[1];
+                sp.bottom = values[2];
+                return sp;
+              case 4:
+                sp.top = values[0];
+                sp.right = values[1];
+                sp.bottom = values[2];
+                sp.left = values[3];
+                return sp;
             }
             return sp;
-        });
-    return spacing;
+          });
+  return spacing;
 }
 
 int decode_hex_str(std::string_view str) {
-    char buf[3] = {str[0], str[1], '\0'};
-    return (uint8_t)(std::strtoul(buf, nullptr, 16));
+  char buf[3] = {str[0], str[1], '\0'};
+  return (uint8_t)(std::strtoul(buf, nullptr, 16));
 }
 
-int combine_digits(const std::vector<int> digits) {
-    int val = 0;
-    for (auto d : digits) {
-        val = (val * 10) + d;
-    }
-    return val;
+int combine_digits(std::vector<int> const digits) {
+  int val = 0;
+  for (auto d : digits) {
+    val = (val * 10) + d;
+  }
+  return val;
 }
 
 auto parse_hex_digit = detail::parse_char_class([](char ch) {
-    ch = toupper(ch);
-    return (ch >= '0' || ch <= '9') || (ch >= 'A' || ch <= 'F');
+  ch = toupper(ch);
+  return (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'F');
 });
 
 Parser<uint8_t> parse_byte() {
-    auto parser =
-        parse_str("0x").or_else(parse_str("0X"))
-        .and_then(parse_n(parse_hex_digit, 2).transform(decode_hex_str))
-        .or_else(parse_n(parse_digit(), 1, 3).transform(combine_digits));
-    return parser.transform([](int val) {return static_cast<uint8_t>(val); });
+  auto parser =
+      parse_str("0x")
+          .or_else(parse_str("0X"))
+          .and_then(parse_n(parse_hex_digit, 2).transform(decode_hex_str))
+          .or_else(parse_n(parse_digit(), 1, 3).transform(combine_digits));
+  return parser.transform([](int val) { return static_cast<uint8_t>(val); });
 }
 
-Parser<Color> parse_color()
-{
-    auto is_hexit = [](char ch) {
-        ch = toupper(ch);
-        return (ch >= '0' || ch <= '9') || (ch >= 'A' || ch <= 'F');
-    };
+Parser<Color> parse_color() {
+  auto is_hexit = [](char ch) {
+    ch = toupper(ch);
+    return (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'F');
+  };
 
-    auto parse_hex_digit(detail::parse_char_class(is_hexit));
+  auto parse_hex_digit(detail::parse_char_class(is_hexit));
 
-    auto hex_color_parser = 
-        parse_literal('#')
-        .and_then(parse_n(parse_hex_digit, 6))
-        .transform([](std::string_view value) {
-            Color color;
-            color.r = decode_hex_str(value.substr(0, 2));
-            color.g = decode_hex_str(value.substr(2, 4));
-            color.b = decode_hex_str(value.substr(4, 6));
-            return color;
-        });
+  auto hex_color_parser =
+      parse_literal('#')
+          .and_then(parse_n(parse_hex_digit, 6))
+          .transform([](std::string_view value) {
+            return Color{.r = decode_hex_str(value.substr(0, 2)),
+                         .g = decode_hex_str(value.substr(2, 4)),
+                         .b = decode_hex_str(value.substr(4, 6))};
+          });
 
-    auto delimiter = parse_ignoring_ws(parse_literal(','));
-    auto rgb_parser = parse_str("rgb")
-        .skip(parse_ws())
-        .and_then(parse_literal('('))
-        .and_then(
-            parse_delimited_by(parse_byte(), delimiter, parse_literal(')')))
-        .skip(parse_literal(')'))
-        .transform([] (auto values) {
-            return Color{
-                .r = values[0],
-                .g = values[1],
-                .b = values[2]
-            };
-        });
-
-    return hex_color_parser.or_else(rgb_parser);
+  auto delimiter = parse_ignoring_ws(parse_literal(','));
+  auto rgb_parser =
+      parse_str("rgb")
+          .skip(parse_opt_ws())
+          .and_then(parse_literal('('))
+          .and_then(
+              parse_delimited_by(parse_byte(), delimiter, parse_literal(')')))
+          .skip(parse_literal(')'))
+          .transform([](auto values) {
+            return Color{.r = values[0], .g = values[1], .b = values[2]};
+          });
+  return hex_color_parser.or_else(rgb_parser);
 }
 
-template<typename T>
+template <typename T>
 Parser<Rule> parse_rule(std::string_view property, Parser<T> rule_value) {
-    return rule_value().transform([property](const T& value) {
-        return Rule {
-            .property = std::string(property),
-            .value = value
-        };
-    });
+  return rule_value().transform([property](T const& value) {
+    return Rule{.property = std::string(property), .value = value};
+  });
 }
 
 Parser<Rule> parse_dimension_rule(std::string_view property) {
-    return parse_dimension().transform([property](const Dimension& dim) {
-        return Rule {
-            .property = std::string(property),
-            .value = dim
-        };
-    });
+  return parse_dimension().transform([property](Dimension const& dim) {
+    return Rule{.property = std::string(property), .value = dim};
+  });
 }
 
 Parser<Rule> parse_color_rule(std::string_view property) {
-    return parse_color().transform([property](const Color& color) {
-        return Rule {
-            .property = std::string(property),
-            .value = color
-        };
-    });
+  return parse_color().transform([property](Color const& color) {
+    return Rule{.property = std::string(property), .value = color};
+  });
 }
 
 Parser<Rule> parse_spacing_rule(std::string_view property) {
-    return parse_spacing().transform([property](const Spacing& spacing) {
-        std::cout << "spacing = " << spacing << std::endl;
-        return Rule {
-            .property = std::string(property),
-            .value = spacing
-        };
-    });
+  return parse_spacing().transform([property](Spacing const& spacing) {
+    return Rule{.property = std::string(property), .value = spacing};
+  });
 }
 
-void print_stylesheet(const StyleSheet& ss) {
-    for (auto it = ss.selectors.begin(); it != ss.selectors.end(); ++it) {
-        std::cout << it->first << ":" << std::endl;
-        for (auto rule : it->second) {
-            std::cout << "  " << rule.property << " = ";
-            std::visit([](auto&& arg){
-                std::cout << arg << std::endl;
-            }, rule.value);
-        }
+void print_stylesheet(StyleSheet const& ss) {
+  for (auto it = ss.selectors.begin(); it != ss.selectors.end(); ++it) {
+    std::cout << it->first << ":" << std::endl;
+    for (auto rule : it->second) {
+      std::cout << "  " << rule.property << " = ";
+      std::visit([](auto&& arg) { std::cout << arg << std::endl; }, rule.value);
     }
+  }
+}
+
+Parser<Rule> GetRuleParser(std::string_view property) {
+  static std::unordered_map<std::string, Parser<Rule> (*)(std::string_view)>
+      prop_parsers = {
+          {"padding", parse_spacing_rule},
+          {"height", parse_dimension_rule},
+          {"width", parse_dimension_rule},
+          {"color", parse_color_rule},
+      };
+  return prop_parsers[std::string(property)](property);
 }
 
 void ParseStyleSheet(std::string_view input) {
+  auto variable =
+      parse_sequence({parse_any_of("_.#").or_else(parse_alpha()),
+                      parse_n(parse_alnum(), 1).or_else(parse_any_of("-"))});
 
-    auto variable = parse_sequence({
-        parse_any_of("_.#").or_else(parse_alpha()),
-        parse_some(parse_alnum())
-    });
+  auto rule = variable.skip(parse_opt_ws())
+                  .skip(parse_literal(':'))
+                  .skip(parse_opt_ws())
+                  .and_then([](std::string_view prop_name) {
+                    return GetRuleParser(prop_name);
+                  })
+                  .skip(parse_literal(';'))
+                  .skip(parse_opt_ws());
 
-    auto rule = variable
-        .skip(parse_ws())
-        .skip(parse_literal(':'))
-        .skip(parse_ws())
-        .and_then([](std::string_view prop_name) {
-            // TODO:
-            // This is where we will inject a function that takes a prop_name
-            // and retruns the apropriate parser.
-            return parse_dimension_rule(prop_name)
-//            .or_else(parse_spacing_rule(prop_name))
-            .or_else(parse_color_rule(prop_name));
-        })
-        .skip(parse_literal(';'))
-        .skip(parse_ws());
+  auto selector = variable.skip(parse_opt_ws())
+                      .skip(parse_literal('{'))
+                      .skip(parse_opt_ws())
+                      .and_then([rule](std::string_view sel_name) {
+                        return parse_some(rule).transform(
+                            [sel_name](std::vector<Rule> const& rules) {
+                              return make_pair(sel_name, rules);
+                            });
+                      })
+                      .skip(parse_opt_ws())
+                      .skip(parse_literal('}'))
+                      .skip(parse_opt_ws());
 
-    auto selector = variable
-        .skip(parse_ws())
-        .skip(parse_literal('{'))
-        .skip(parse_ws())
-        .and_then([rule](std::string_view sel_name) {
-            return parse_some(rule).transform([sel_name](const std::vector<Rule>& rules) {
-                return make_pair(sel_name, rules);
-            });
-        })
-        .skip(parse_ws())
-        .skip(parse_literal('}'))
-        .skip(parse_ws());
-
-    auto styles = parse_some(selector).transform([](auto selectors) {
-        StyleSheet ss;
-        for (auto [selector, rules] : selectors) {
-            ss.selectors[std::string(selector)] = rules;
-        }
-        return ss;
-    });
-
-    auto result = styles(input);
-    if (result) {
-        if (result.error.size()) {
-            std::cerr << "It says it worked but: " << result.error << std::endl;
-        }
-        print_stylesheet(result.value());
-    } else {
-        std::cerr << "fail at " << result.input << std::endl;
+  auto styles = parse_n(selector, 1).transform([](auto selectors) {
+    StyleSheet ss;
+    for (auto [selector, rules] : selectors) {
+      ss.selectors[std::string(selector)] = rules;
     }
+    return ss;
+  });
+
+  auto result = styles(input);
+  if (result) {
+    if (!result.input.empty()) {
+      std::cerr << "Stopped parsing at " << result.input << std::endl;
+    }
+    if (result.error.size()) {
+      std::cerr << "It says it worked but: " << result.error << std::endl;
+    }
+    print_stylesheet(result.value());
+  } else {
+    std::cerr << "failed at " << result.input << std::endl;
+  }
 }
 
-std::string read_file(std::string_view filename)
-{
+std::string read_file(std::string_view filename) {
   std::ifstream f(filename, 0);
   if (!f) {
-    throw std::runtime_error( "failed to open file" );
+    throw std::runtime_error("failed to open file");
   }
 
   std::ostringstream ss;
@@ -283,15 +254,13 @@ std::string read_file(std::string_view filename)
   return ss.str();
 }
 
-int main(int argc, char **argv)
-{
-    if (argc != 2)
-    {
-        std::cerr << "enter a filename" << std::endl;
-        return -1;
-    }
+int main(int argc, char** argv) {
+  if (argc != 2) {
+    std::cerr << "enter a filename" << std::endl;
+    return -1;
+  }
 
-    std::string content = read_file(argv[1]);
+  std::string content = read_file(argv[1]);
 
-    ParseStyleSheet(content);
+  ParseStyleSheet(content);
 }

--- a/src/parser.h
+++ b/src/parser.h
@@ -1,585 +1,525 @@
 #ifndef __PARSER_H__
 #define __PARSER_H__
 
+#include <fmt/format.h>
 #include <functional>
+#include <iostream>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <variant>
 #include <vector>
-#include <iostream>
-
-#include <fmt/format.h>
+#include <assert.h>
 
 using unit = std::monostate;
 
-template<class T>
+template <class T>
 class Parser;
 template <class T>
-struct ParseResult
-{
-    // Maybe result should be std::expect?
-    std::optional<T> result;
-    std::string_view input;
-    std::string error;
+struct ParseResult {
+  // Maybe result should be std::expect?
+  std::optional<T> result;
+  std::string_view input;
+  std::string error;
 
-    operator bool() const { return result.has_value(); }
-    bool operator!() const { return !result.has_value(); }
-    bool has_value() const { return result.has_value(); }
-    T& value() { return *result; }
-    const T& value() const { return *result; }
+  operator bool() const { return result.has_value(); }
+  bool operator!() const { return !result.has_value(); }
+  bool has_value() const { return result.has_value(); }
+  T& value() { return *result; }
+  T const& value() const { return *result; }
 };
 
 // Helper functions for constructing ParseResults
-template<typename T>
+template <typename T>
 ParseResult<T> make_parse_result(T value, std::string_view remaining) {
-    return ParseResult<T>{
-        .result = std::move(value),
-        .input = remaining
-    };
+  return ParseResult<T>{.result = std::move(value), .input = remaining};
 }
 
-template<typename T>
-ParseResult<T> empty_parse_result(std::string_view input, const std::string& error) {
-    return ParseResult<T>{
-        .result = std::nullopt,
-        .input = input,
-        .error = error
-    };
+template <typename T>
+ParseResult<T> empty_parse_result(std::string_view input,
+                                  std::string const& error) {
+  return ParseResult<T>{.result = std::nullopt, .input = input, .error = error};
 }
 
 namespace detail {
-    template<typename T>
-    struct parser_impl {
-        template<typename U>
-        static auto skip(const Parser<T>& parser, const Parser<U>& next) {
-            return Parser<T>([parser, next](std::string_view input) {
-                auto result = parser(input);
-                if (!result) {
-                    return empty_parse_result<T>(input, result.error);
-                }
-                auto next_result = next(result.input);
-                if (!next_result) {
-                    return empty_parse_result<T>(result.input, next_result.error);
-                }
-                return make_parse_result(
-                    result.value(),
-                    next_result.input
-                );
-            });
-        }
-    };
+template <typename T>
+struct parser_impl {
+  template <typename U>
+  static auto skip(Parser<T> const& parser, Parser<U> const& next) {
+    return Parser<T>([parser, next](std::string_view input) {
+      auto result = parser(input);
+      if (!result) {
+        return empty_parse_result<T>(input, result.error);
+      }
+      auto next_result = next(result.input);
+      if (!next_result) {
+        return empty_parse_result<T>(result.input, next_result.error);
+      }
+      return make_parse_result(result.value(), next_result.input);
+    });
+  }
+};
 
-    struct discontinuous_tag {};
-    struct discontinuous_string_view : std::string_view, discontinuous_tag {
-        discontinuous_string_view(const std::string_view& other) 
-            : std::string_view(other) {}
-        discontinuous_string_view& operator=(const std::string_view& other) {
-            std::string_view::operator=(other);
-            return *this;
-        }        
-    };
+struct discontinuous_tag {};
+struct discontinuous_string_view : std::string_view, discontinuous_tag {
+  discontinuous_string_view(std::string_view const& other)
+      : std::string_view(other) {}
+  discontinuous_string_view& operator=(std::string_view const& other) {
+    std::string_view::operator=(other);
+    return *this;
+  }
+};
 
-    template<typename T>
-    using result_vector_t = std::conditional_t<
-        std::is_same_v<T, std::string_view>,
-        std::vector<discontinuous_string_view>,
-        std::vector<T>
-    >;
+template <typename T>
+using result_vector_t =
+    std::conditional_t<std::is_same_v<T, std::string_view>,
+                       std::vector<discontinuous_string_view>, std::vector<T>>;
 
+template <class T>
+std::vector<T> append(T const& item, std::vector<T>& vec) {
+  vec.push_back(item);
+  return vec;
+}
 
-    template<class T>
-    std::ostream& operator<<(std::ostream& out, const std::vector<T>& xs) {
-        out << "[";
-        for (auto it = xs.begin(); it != xs.end(); ++it) {
-            out << *it;
-            if (it + 1 != xs.end()) {
-                out << ",";
-            }
-        }
-        out << "]";
-        return out;
-    }
-
-    std::ostream& operator<<(std::ostream& out, const unit _) {
-        out << "unit";
-        return out;
-    }
-
-    template<class T>
-    std::ostream& operator<<(std::ostream& out, const ParseResult<T>& res) {
-        if (res) {
-            out << res.value();
-        } else {
-            out << res.error;
-        }
-        return out;
-    }
+std::string_view append(std::string_view item, std::string_view sv) {
+  assert(sv.data() + sv.size() == item.data());
+  return std::string_view(sv.data(), sv.size() + item.size());
 }
 
 template <class T>
-class Parser
-{
-public:
-    using value_type = T;
-    using Parse = std::function<ParseResult<T>(std::string_view)>;
-
-    Parser(Parse parse) : parse_(parse) {}
-
-    ParseResult<T> operator()(std::string_view input) const
-    {
-        return parse_(input);
+std::ostream& operator<<(std::ostream& out, std::vector<T> const& xs) {
+  out << "[";
+  for (auto it = xs.begin(); it != xs.end(); ++it) {
+    out << *it;
+    if (it + 1 != xs.end()) {
+      out << ",";
     }
+  }
+  out << "]";
+  return out;
+}
 
-    Parser<T> or_else(Parser<T> parser) const
-    {
-        Parse self = parse_;
-        return Parser<T>([self, parser](std::string_view input) {
-            auto result = self(input);
-            if (!result) {
-                return parser(input);
-            }
-            return result;
-        });
-    }
+std::ostream& operator<<(std::ostream& out, unit const _) {
+  out << "unit";
+  return out;
+}
 
-    // fn is a function from T to a Parser<U>
-    template <typename F>
-    requires (!std::is_base_of_v<Parser<typename std::invoke_result_t<F, T>::value_type>, F>)
-    auto and_then(F&& fn) const
-    {
-        using ReturnParser = std::invoke_result_t<F, T>;
-        using U = typename ReturnParser::value_type; // Extract U from Parser<U>
-        Parser self = parse_;
-        return Parser<U>([self, fn](std::string_view input) {
-            auto result = self(input);
-            if (!result) {
-                return empty_parse_result<U>(input, result.error);
-            }
-            ReturnParser then_parser = fn(result.value());
-            return then_parser(result.input);
-        });
-    }
+template <class T>
+std::ostream& operator<<(std::ostream& out, ParseResult<T> const& res) {
+  if (res) {
+    out << res.value();
+  } else {
+    out << res.error;
+  }
+  return out;
+}
+}  // namespace detail
 
-    template<typename U>
-    auto and_then(const Parser<U>& next) const {
-        Parser self = parse_;
-        return Parser<U>([self, next](std::string_view input) {
-            auto result = self(input);
-            if (!result) {
-                return empty_parse_result<U>(input, result.error);
-            }
-            return next(result.input);
-        });
-    }
+template <class T>
+class Parser {
+ public:
+  using value_type = T;
+  using Parse = std::function<ParseResult<T>(std::string_view)>;
 
-    template<typename U>
-    Parser<T> and_not(const Parser<U>& next) const {
-        Parser self = parse_;
-        return Parser<T>([self, next](std::string_view input) {
-            auto result = self(input);
-            if (!result) {
-                return empty_parse_result<T>(input, result.error);
-            }
-            auto next_result = next(result.input);
-            if (next_result) {
-                return empty_parse_result<T>(
-                    input,
-                    fmt::format("Expected failure but parsed {}", next_result.value())
-                );
-            }
-            return result;
-        });
-    }
+  Parser(Parse parse) : parse_(parse) {}
 
-    template<typename U>
-    auto skip(const Parser<U>& next) const {
-        return detail::parser_impl<T>::skip(*this, next);
-    }    
+  ParseResult<T> operator()(std::string_view input) const {
+    return parse_(input);
+  }
 
-    template<typename F>
-    auto transform(F&& fn) const {
-        using U = std::invoke_result_t<F, T>;
-        Parser self = parse_;
-        return Parser<U>([self, fn](std::string_view input) {
-            auto result = self(input);
-            if (!result) {
-                return empty_parse_result<U>(input, result.error);
-            }
-            return make_parse_result<U>(
-                fn(result.value()),
-                result.input);
-        });
-    }
+  Parser<T> or_else(Parser<T> parser) const {
+    Parse self = parse_;
+    return Parser<T>([self, parser](std::string_view input) {
+      auto result = self(input);
+      if (!result) {
+        return parser(input);
+      }
+      return result;
+    });
+  }
 
-    template<typename U>
-    auto as(U value) const {
-        return transform([value](auto&&) -> U {
-            return value;
-        });
-    }
+  // fn is a function from T to a Parser<U>
+  template <typename F>
+    requires(!std::is_base_of_v<
+             Parser<typename std::invoke_result_t<F, T>::value_type>, F>)
+  auto and_then(F&& fn) const {
+    using ReturnParser = std::invoke_result_t<F, T>;
+    using U = typename ReturnParser::value_type;  // Extract U from Parser<U>
+    Parser self = parse_;
+    return Parser<U>([self, fn](std::string_view input) {
+      auto result = self(input);
+      if (!result) {
+        return empty_parse_result<U>(input, result.error);
+      }
+      ReturnParser then_parser = fn(result.value());
+      return then_parser(result.input);
+    });
+  }
 
-private:
-    Parse parse_;
+  template <typename U>
+  auto and_then(Parser<U> const& next) const {
+    Parser self = parse_;
+    return Parser<U>([self, next](std::string_view input) {
+      auto result = self(input);
+      if (!result) {
+        return empty_parse_result<U>(input, result.error);
+      }
+      return next(result.input);
+    });
+  }
+
+  template <typename U>
+  Parser<T> and_not(Parser<U> const& next) const {
+    Parser self = parse_;
+    return Parser<T>([self, next](std::string_view input) {
+      auto result = self(input);
+      if (!result) {
+        return empty_parse_result<T>(input, result.error);
+      }
+      auto next_result = next(result.input);
+      if (next_result) {
+        return empty_parse_result<T>(
+            input,
+            fmt::format("Expected failure but parsed {}", next_result.value()));
+      }
+      return result;
+    });
+  }
+
+  template <typename U>
+  auto skip(Parser<U> const& next) const {
+    return detail::parser_impl<T>::skip(*this, next);
+  }
+
+  template <typename F>
+  auto transform(F&& fn) const {
+    using U = std::invoke_result_t<F, T>;
+    Parser self = parse_;
+    return Parser<U>([self, fn](std::string_view input) {
+      auto result = self(input);
+      if (!result) {
+        return empty_parse_result<U>(input, result.error);
+      }
+      return make_parse_result<U>(fn(result.value()), result.input);
+    });
+  }
+
+  template <typename U>
+  auto as(U value) const {
+    return transform([value](auto&&) -> U { return value; });
+  }
+
+ private:
+  Parse parse_;
 };
 
 using StringParser = Parser<std::string_view>;
 
 namespace detail {
-template<>
+template <>
 struct parser_impl<std::string_view> {
-    // When skipping over input the result becomes discontinuous
-    template<typename U>
-    static auto skip(const StringParser& parser, const Parser<U>& next) {
-        Parser<detail::discontinuous_string_view> to_dc = parser.transform([](auto value) {
-            return detail::discontinuous_string_view(value);
-        });
-        return to_dc.skip(next);
-    }
+  // When skipping over input the result becomes discontinuous
+  template <typename U>
+  static auto skip(StringParser const& parser, Parser<U> const& next) {
+    Parser<detail::discontinuous_string_view> to_dc = parser.transform(
+        [](auto value) { return detail::discontinuous_string_view(value); });
+    return to_dc.skip(next);
+  }
 };
 
-Parser<detail::discontinuous_string_view> to_discontinuous(StringParser parser) {
-    return parser.transform([](auto value) {
-        return detail::discontinuous_string_view(value);
-    });
+Parser<detail::discontinuous_string_view> to_discontinuous(
+    StringParser parser) {
+  return parser.transform(
+      [](auto value) { return detail::discontinuous_string_view(value); });
 }
 
-}
+}  // namespace detail
 
-template<typename T>
+template <typename T>
 Parser<T> parse_never() {
-    return Parser<T>([](std::string_view input) {
-        return empty_parse_result<T>(input, "Error: never");
-    });
+  return Parser<T>([](std::string_view input) {
+    return empty_parse_result<T>(input, "Error: never");
+  });
 }
 
-template<typename T>
+template <typename T>
 Parser<T> pure(T value) {
-    return Parser<T>([value](std::string_view input) {
-        return make_parse_result(value, input);  // Succeeds with value, doesn't consume input
-    });
+  return Parser<T>([value](std::string_view input) {
+    return make_parse_result(
+        value, input);  // Succeeds with value, doesn't consume input
+  });
 }
 
 namespace detail {
 
-    StringParser parse_char_class(std::function<bool(char)> matcher) {
-        return StringParser([matcher] (std::string_view input){
-            if (!input.empty()) {
-                char ch = input.front();
-                if (matcher(ch)) {
-                    return make_parse_result<std::string_view>(
-                        input.substr(0, 1),
-                        input.substr(1)
-                    );
-                }
-            }
-            return empty_parse_result<std::string_view>(
-                input,
-                fmt::format("Error: unexpected char {}", input.front())
-            );
-        });
+// Helper for all the std::is* functions for chars.
+StringParser parse_char_class(std::function<int(int)> matcher) {
+  return StringParser([matcher](std::string_view input) {
+    if (matcher(static_cast<int>(input.front())) != 0) {
+      return make_parse_result<std::string_view>(input.substr(0, 1),
+                                                 input.substr(1));
     }
-    
-    bool str_contains(std::string_view str, char ch) {
-        for (char c : str) {
-            if (c == ch) {
-                return true;
-            }
-        }
-        return false;
-    }    
+    return empty_parse_result<std::string_view>(
+        input, fmt::format("Error: unexpected char {}", input.front()));
+  });
 }
 
-StringParser parse_literal(char ch)
-{
-    return StringParser([ch](std::string_view input) {
-        if (!input.empty() && input.front() == ch) {
-            return make_parse_result(input.substr(0, 1),
-                input.substr(1));
-        } else {
-            return empty_parse_result<std::string_view>(
-                input,
-                fmt::format("Expected {} but saw {}", ch, input.front()));
-        }
-    });
+bool str_contains(std::string_view str, char ch) {
+  return std::find_if(str.begin(), str.end(),
+                      [ch](char c) { return c == ch; }) != str.end();
+}
+}  // namespace detail
+
+StringParser parse_literal(char ch) {
+  return StringParser([ch](std::string_view input) {
+    if (!input.empty() && input.front() == ch) {
+      return make_parse_result(input.substr(0, 1), input.substr(1));
+    } else {
+      return empty_parse_result<std::string_view>(
+          input, fmt::format("Expected {} but saw {}", ch, input.front()));
+    }
+  });
 }
 
-StringParser parse_range(char first, char last)
-{
-    return StringParser([first, last](std::string_view input) {
-        if (!input.empty()) {
-            char ch = input.front();
-            if (ch >= first && ch <= last) {
-                return make_parse_result(input.substr(0, 1),
-                    input.substr(1));
-            }
-        }
-        return empty_parse_result<std::string_view>(
-            input,
-            fmt::format("Error: expected [{}-{}] but saw {}", first, last, input.front()));
-    });
+StringParser parse_range(char first, char last) {
+  return StringParser([first, last](std::string_view input) {
+    if (!input.empty()) {
+      char ch = input.front();
+      if (ch >= first && ch <= last) {
+        return make_parse_result(input.substr(0, 1), input.substr(1));
+      }
+    }
+    return empty_parse_result<std::string_view>(
+        input, fmt::format("Error: expected [{}-{}] but saw {}", first, last,
+                           input.front()));
+  });
 }
 
-StringParser parse_str(std::string_view str)
-{
-    return StringParser([str](std::string_view input) {
-        if (input.starts_with(str)) {
-            return make_parse_result(
-                input.substr(0, str.size()),
-                input.substr(str.size())
-            );
-        } else {
-            return empty_parse_result<std::string_view>(
-                input,
-                fmt::format("Error: expected {} but saw {}", str, input)
-            );
-        } 
-    });
+StringParser parse_str(std::string_view str) {
+  return StringParser([str](std::string_view input) {
+    if (input.starts_with(str)) {
+      return make_parse_result(input.substr(0, str.size()),
+                               input.substr(str.size()));
+    } else {
+      return empty_parse_result<std::string_view>(
+          input, fmt::format("Error: expected {} but saw {}", str, input));
+    }
+  });
 }
 
 // Matches a char if it is in the set of chars in src.
-StringParser parse_any_of(std::string_view str)
-{
-    return StringParser([str](std::string_view input){
-        if (!detail::str_contains(str, input.front())) {
-            return empty_parse_result<std::string_view>(
-                input,
-            fmt::format("Error: expected any of {} but saw {}", str, input.front()));
-        }
-        return make_parse_result(input.substr(0, 1), input.substr(1));
-    });
+StringParser parse_any_of(std::string_view str) {
+  return StringParser([str](std::string_view input) {
+    if (!detail::str_contains(str, input.front())) {
+      return empty_parse_result<std::string_view>(
+          input, fmt::format("Error: expected any of {} but saw {}", str,
+                             input.front()));
+    }
+    return make_parse_result(input.substr(0, 1), input.substr(1));
+  });
 }
 
-Parser<int> parse_digit(int first = 0, int last = 9)
-{
-    return Parser<int>([first, last](std::string_view input) {
-        if (!input.empty()) {
-            char ch = input.front();
-            if (std::isdigit(ch)) {
-                int digit  = ch - '0';
-                if (digit >= first && digit <= last) {
-                    return make_parse_result(digit, input.substr(1));
-                }
-            }
-        }
-        return empty_parse_result<int>(
-            input,
-            fmt::format("Error: expected digit from [{} - {}] but saw {}", first, last, input.front())
-        );
-    });
+Parser<int> parse_digit(int first = 0, int last = 9) {
+  auto is_valid_digit = [first, last](int ch) -> int {
+    int val = ch - '0';
+    return (std::isdigit(ch) && val >= first && val <= last) ? 1 : 0;
+  };
+  return detail::parse_char_class(is_valid_digit)
+      .transform([](std::string_view str) {
+        return static_cast<int>(str.front() - '0');
+      });
+}
+
+// Zero or more.
+template <typename T>
+Parser<std::vector<T>> parse_some(Parser<T> parser,
+                                  std::optional<size_t> max = std::nullopt) {
+  return Parser<std::vector<T>>([parser, max](std::string_view input) {
+    std::vector<T> results;
+    while (!input.empty()) {
+      auto result = parser(input);
+      if (!result) {
+        break;
+      }
+      if (max && results.size() == *max) {
+        return empty_parse_result<std::vector<T>>(
+            input, fmt::format("Error: parsed more than {} reults", *max));
+      }
+      results.push_back(result.value());
+      input = result.input;
+    }
+    return make_parse_result(results, input);
+  });
 }
 
 template <typename T>
-Parser<std::vector<T>> parse_some(Parser<T> parser)
-{
-    return Parser<std::vector<T>>([parser](std::string_view input) {
-        std::vector<T> results;
-        while (!input.empty()) {
-            auto result = parser(input);
-            if (!result) {
-                break;
-            }
-            results.push_back(result.value());
-            input = result.input;
-        }
-        return make_parse_result(results, input);
-    });
+Parser<std::vector<T>> parse_n(Parser<T> parser, size_t min,
+                               std::optional<size_t> max = std::nullopt) {
+  return parse_some(parser, max).and_then([min](auto const& results) {
+    if (results.size() < min) {
+      return parse_never<std::vector<T>>();
+    }
+    return pure(results);
+  });
 }
 
-template <typename T>
-Parser<std::vector<T>> parse_n(Parser<T> parser, int min, std::optional<int> max = std::nullopt)
-{
-    return Parser<std::vector<T>>([parser, min, max](std::string_view input) {
-        std::vector<T> results;
-        int count = 0;
-        int count_max = max.value_or(min);
-
-        std::string error;
-        while (!input.empty() && count < count_max) {
-            auto result = parser(input);
-            if (!result) {
-                error = result.error;
-                break;
-            }
-            results.push_back(result.value());
-            input = result.input;
-            
-            ++count;
-        }
-        if (count < min) {
-            return empty_parse_result<std::vector<T>>(
-                input,
-                fmt::format(
-                    "Error: expected to match {} times but saw {}\n\tInner: {}",
-                        min, count, error)
-            );
-        }
-        return make_parse_result(results, input);
-    });
+StringParser parse_some(StringParser parser,
+                        std::optional<size_t> max = std::nullopt) {
+  return StringParser([parser, max](std::string_view input) {
+    size_t size = 0;
+    size_t count = 0;
+    std::string_view inp = input;
+    while (!inp.empty()) {
+      auto result = parser(inp);
+      if (!result) {
+        break;
+      }
+      if (max && count == *max) {
+        return empty_parse_result<std::string_view>(
+            input, fmt::format("Error: parsed more than {} results", *max));
+      }
+      ++count;
+      size += result.value().size();
+      inp = result.input;
+    }
+    return make_parse_result(input.substr(0, size), inp);
+  });
 }
 
-StringParser parse_some(StringParser parser)
-{
-    return StringParser([parser](std::string_view input) {
-        size_t count = 0;
-        std::string_view inp = input;
-        while (!inp.empty()) {
-            auto result = parser(inp);
-            if (!result) {
-                break;
-            }
-            count += result.value().size();
-            inp = result.input;
-        }
-        // if (count == 0) {
-        //     return empty_parse_result<std::string_view>(input);
-        // }
-        return make_parse_result(input.substr(0, count), inp);
-    });
-}
+StringParser parse_n(StringParser parser, size_t min,
+                     std::optional<int> max = std::nullopt) {
+  // This version can't use the same combinator as above because of the
+  // continuous string_view optiization.
+  return StringParser([parser, min, max](std::string_view input) {
+    int count = 0;
+    size_t pos = 0;
+    std::string_view inp = input;
+    std::string error;
+    while (!inp.empty()) {
+      auto result = parser(inp);
+      if (!result) {
+        error = result.error;
+        break;
+      }
 
-StringParser parse_n(StringParser parser, int min, std::optional<int> max = std::nullopt)
-{
-    return StringParser([parser, min, max](std::string_view input) {
-        int count = 0;
-        int count_max = max.value_or(min);
-        size_t pos = 0;
-        std::string_view inp = input;
-        std::string error;
-        while (!inp.empty() && count < count_max) {
-            auto result = parser(inp);
-            if (!result) {
-                error = result.error;
-                break;
-            }
-            pos += result.value().size();
-            inp = result.input;
-            ++count;
-        }
-        if (count < min) {
-            return empty_parse_result<std::string_view>(
-                inp,
-                fmt::format(
-                    "Error: expected {} occurences but only saw {}\n\tInner: {}",
-                    min, count, error)
+      if (max && count == *max) {
+        return empty_parse_result<std::string_view>(
+            result.input,
+            fmt::format("Error: parsed more than {} results", *max));
+      }
+      pos += result.value().size();
+      inp = result.input;
+      ++count;
+    }
+    if (count < min) {
+      return empty_parse_result<std::string_view>(
+          inp, fmt::format(
+                   "Error: expected {} occurences but only saw {}\n\tInner: {}",
+                   min, count, error)
 
-            );
-        }
-        return make_parse_result(input.substr(0, pos), inp);
-    });
+      );
+    }
+    return make_parse_result(input.substr(0, pos), input.substr(pos));
+  });
 }
 
 StringParser parse_sequence(std::initializer_list<StringParser> parsers) {
-    std::vector<StringParser> ps(parsers);
-    return StringParser([ps] (std::string_view input) {
-        size_t count = 0;
-        std::string_view inp = input;
-        for (auto parser: ps) {
-            if (input.empty()) {
-                return empty_parse_result<std::string_view>(
-                    inp,
-                    fmt::format("Error: reached end of input.")
-                );
-            }
-            auto result = parser(inp);
-            if (!result) {
-                return result;
-            }
-            count += result.value().size();
-            inp = result.input;
-        }
-        return make_parse_result<std::string_view>(
-            input.substr(0, count),
-            input.substr(count)
-        );
-    });
+  std::vector<StringParser> ps(parsers);
+  return StringParser([ps](std::string_view input) {
+    size_t count = 0;
+    std::string_view inp = input;
+    for (auto parser : ps) {
+      if (input.empty()) {
+        return empty_parse_result<std::string_view>(
+            inp, fmt::format("Error: reached end of input."));
+      }
+      auto result = parser(inp);
+      if (!result) {
+        return result;
+      }
+      count += result.value().size();
+      inp = result.input;
+    }
+    return make_parse_result<std::string_view>(input.substr(0, count),
+                                               input.substr(count));
+  });
 }
 
-template<typename T, typename D, typename S>
+template <typename T, typename D, typename S>
 Parser<detail::result_vector_t<T>> parse_delimited_by(
-    Parser<T> parser,
-    Parser<D> delimiter,
-    Parser<S> terminator,
-    std::optional<int> max = std::nullopt
-) {
-    using ResultType = detail::result_vector_t<T>;
-    return Parser<ResultType>([=](std::string_view input) {
+    Parser<T> parser, Parser<D> delimiter, Parser<S> terminator,
+    std::optional<int> max = std::nullopt) {
+  using ResultType = detail::result_vector_t<T>;
+  return Parser<ResultType>([=](std::string_view input) {
+    auto tokens_result = parse_some(parser.skip(delimiter))(input);
 
-        auto tokens_result = parse_some(parser.skip(delimiter))(input);
+    if (!tokens_result) {
+      return empty_parse_result<ResultType>(input, tokens_result.error);
+    }
+    input = tokens_result.input;
 
-        if (!tokens_result) {
-            return empty_parse_result<ResultType>(input, tokens_result.error);
-        }
-        input = tokens_result.input;
+    auto last_token_result = parser(input);
 
-        auto last_token_result = parser(input);
+    if (!last_token_result) {
+      return empty_parse_result<ResultType>(input, last_token_result.error);
+    }
+    // now expect the terminator
+    auto term_result = terminator(last_token_result.input);
+    if (!term_result) {
+      return empty_parse_result<ResultType>(term_result.input,
+                                            term_result.error);
+    }
 
-        if (!last_token_result) {
-            return empty_parse_result<ResultType>(input, last_token_result.error);
-        }
-        // now expect the terminator
-        auto term_result = terminator(last_token_result.input);
-        if (!term_result) {
-            return empty_parse_result<ResultType>(term_result.input, term_result.error);
-        }
+    auto results = tokens_result.value();
+    results.push_back(last_token_result.value());
 
-        auto results = tokens_result.value();
-        results.push_back(last_token_result.value());
-
-        return make_parse_result(results, last_token_result.input);
-    });
+    return make_parse_result(results, last_token_result.input);
+  });
 }
 
 StringParser parse_alpha() {
-    return detail::parse_char_class([] (char ch) { return std::isalpha(ch); } );
+  return detail::parse_char_class(static_cast<int (*)(int)>(&std::isalpha));
 }
 
 StringParser parse_alnum() {
-    return detail::parse_char_class([] (char ch) { return std::isalnum(ch); } );
+  return detail::parse_char_class(static_cast<int (*)(int)>(&std::isalnum));
 }
 
-Parser<unit> parse_ws(bool optional = true) {
-    return Parser<unit>([optional] (std::string_view input) {
-        bool saw_ws = false;
-        while (!input.empty() && (std::isblank(input.front()) || input.front() == '\n')) {
-            input.remove_prefix(1);
-            saw_ws = true;
-        }
-        if (!optional && !saw_ws) {
-            return empty_parse_result<unit>(input, "Error: failed to parse whitespace");
-        }
-        return make_parse_result(unit{}, input);
-    });
+StringParser parse_space() {
+  return detail::parse_char_class(static_cast<int (*)(int)>(&std::isspace));
 }
 
-template<typename T, typename U>
+Parser<unit> parse_opt_ws() { return parse_some(parse_space()).as(unit{}); }
+
+Parser<unit> parse_ws() { return parse_n(parse_space(), 1).as(unit{}); }
+
+template <typename T, typename U>
 Parser<T> parse_ignoring(Parser<T> parser, Parser<U> ignore) {
-    return parser.skip(ignore).or_else(ignore.and_then(parser).skip(ignore));
+  return parser.skip(ignore).or_else(ignore.and_then(parser).skip(ignore));
 }
 
-template<typename U>
-Parser<detail::discontinuous_string_view> parse_ignoring(StringParser parser, Parser<U> ignore) {
-    return parse_ignoring(detail::to_discontinuous(parser), ignore);
+template <typename U>
+Parser<detail::discontinuous_string_view> parse_ignoring(StringParser parser,
+                                                         Parser<U> ignore) {
+  return parse_ignoring(detail::to_discontinuous(parser), ignore);
 }
 
-template<typename T>
-Parser<T> parse_ignoring_ws(Parser<T> parser) {
-    return parse_ignoring(parser, parse_ws());
-}
-
-Parser<detail::discontinuous_string_view> parse_ignoring_ws(StringParser parser) {
-    return parse_ignoring(parser, parse_ws());
+Parser<detail::discontinuous_string_view> parse_ignoring_ws(
+    StringParser parser) {
+  return parse_ignoring(parser, parse_opt_ws());
 }
 
 template <typename T>
-Parser<T> recursive_parser(std::function<Parser<T>(const Parser<T>&)> parser_builder) {
-    auto recursive_parser_ptr = std::make_shared<Parser<T>>(parse_never<T>());
+Parser<T> recursive_parser(
+    std::function<Parser<T>(Parser<T> const&)> parser_builder) {
+  auto recursive_parser_ptr = std::make_shared<Parser<T>>(parse_never<T>());
 
-    // Build the parser using the parser_builder lambda
-    Parser<T> full_parser = parser_builder(*recursive_parser_ptr);
+  // Build the parser using the parser_builder lambda
+  Parser<T> full_parser = parser_builder(*recursive_parser_ptr);
 
-    *recursive_parser_ptr = full_parser;
+  *recursive_parser_ptr = full_parser;
 
-    return *recursive_parser_ptr;
+  return *recursive_parser_ptr;
 }
 
-#endif // __PARSER_H__
+#endif  // __PARSER_H__

--- a/src/test/mparse_test.cpp
+++ b/src/test/mparse_test.cpp
@@ -1,287 +1,272 @@
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
 #include "../parser.h"
 #include "../style_sheet.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 using ::testing::ElementsAre;
 using ::testing::Eq;
 
-template <typename T>
-void dump_result(const std::vector<T> &res)
-{
-    std::cout << "[";
-    for (auto it = res.begin(); it != res.end(); ++it)
-    {
-        std::cout << *it;
-        if ((it + 1) != res.end())
-        {
-            std::cout << ",";
-        }
-    }
-    std::cout << "]";
-}
-namespace parsers
-{
-    auto hexit = parse_range('A', 'F')
-                     .transform([](auto sv)
-                                { return static_cast<int>(10 + (sv.front() - 'A')); })
-                     .or_else(
-                         parse_range('a', 'f')
-                             .transform([](auto sv)
-                                        { return static_cast<int>(10 + (sv.front() - 'a')); }))
-                     .or_else(
-                         parse_range('0', '9')
-                             .transform([](auto sv)
-                                        { return static_cast<int>(sv.front() - '0'); }));
+namespace parsers {
+auto hexit = parse_range('A', 'F')
+                 .or_else(parse_range('a', 'f'))
+                 .transform([](auto sv) {
+                   char ch = std::toupper(sv.front());
+                   return static_cast<int>(10 + (ch - 'A'));
+                 })
+                 .or_else(parse_range('0', '9').transform([](auto sv) {
+                   return static_cast<int>(sv.front() - '0');
+                 }));
 
-    auto hexbyte = parse_n(hexit, 1, 2).transform([](auto hexs)
-                                                  {
-        int val = 0;
-        for (auto h : hexs) {
-            val = (val << 4) + h;
-        }
-        return val; });
+auto hexbyte = parse_n(hexit, 1, 2).transform([](auto hexs) {
+  int val = 0;
+  for (auto h : hexs) {
+    val = (val << 4) + h;
+  }
+  return val;
+});
 
-    Parser<int> number()
-    {
-        auto positive_number = parse_digit(1, 9).and_then([](int val)
-                                                          { return parse_some(parse_digit()).transform([val](std::vector<int> digits)
-                                                                                                       {
-                int result = val;
-                for (auto d : digits) {
-                    result = (result * 10) + d;
-                }
-                return result; }); });
-
-        auto zero = parse_digit(0, 0).and_not(parse_digit(0, 9));
-
-        auto integer = positive_number
-                           .or_else(zero)
-                           .or_else(
-                               parse_literal('-')
-                                   .and_then(positive_number)
-                                   .transform([](int val)
-                                              { return -val; }));
-        return integer;
-    }
-}
-// Demonstrate some basic assertions.
-TEST(ParserTest, ParseStringTest)
-{
-    auto parser = parse_str("hello");
-    auto result = parser("hello");
-
-    EXPECT_TRUE(result.has_value());
-    EXPECT_THAT(result.value(), Eq("hello"));
-}
-
-TEST(ParserText, ParseHelloWorld)
-{
-
-    auto parser = parse_str("hello")
-                      .skip(parse_ws())
-                      .and_then(parse_str(","))
-                      .skip(parse_ws())
-                      .and_then(parse_str("world"));
-
-    auto result = parser("hello, world");
-    assert(result.value() == "world");
-
-    EXPECT_THAT(result.value(), Eq("world"));
-}
-
-TEST(ParserTest, ContainsStr)
-{
-    EXPECT_TRUE(detail::str_contains("hello", 'h'));
-    EXPECT_FALSE(detail::str_contains("hello", 'x'));
-}
-
-TEST(ParserTest, HexNumbers)
-{
-    auto lowercase = {"a", "b", "c", "d", "e", "f"};
-    int expected = 10;
-    for (auto input : lowercase)
-    {
-        EXPECT_EQ(parsers::hexit(input).value(), expected);
-        ++expected;
-    }
-
-    auto uppercase = {"A", "B", "C", "D", "E", "F"};
-    expected = 10;
-    for (auto input : uppercase)
-    {
-        EXPECT_EQ(parsers::hexit(input).value(), expected);
-        ++expected;
-    }
-
-    auto digits = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"};
-    expected = 0;
-    for (auto input : digits)
-    {
-        EXPECT_EQ(parsers::hexit(input).value(), expected);
-        ++expected;
-    }
-
-    EXPECT_FALSE(parsers::hexit("q"));
-    EXPECT_FALSE(parsers::hexit("R"));
-
-    EXPECT_EQ(parsers::hexbyte("0F").value(), 0x0F);
-    EXPECT_EQ(parsers::hexbyte("AA").value(), 0xAA);
-    EXPECT_EQ(parsers::hexbyte("7F").value(), 0x7F);
-    EXPECT_EQ(parsers::hexbyte("80").value(), 0x80);
-
-    EXPECT_FALSE(parsers::hexbyte("G7"));
-    EXPECT_FALSE(parsers::hexbyte("-1"));
-}
-
-TEST(ParserTest, ParseNumber)
-{
-    // These are complicated enough that they should probably go in the library
-    auto integer = parsers::number();
-
-    EXPECT_EQ(integer("0").value(), 0);
-    EXPECT_EQ(integer("123").value(), 123);
-    EXPECT_EQ(integer("-123").value(), -123);
-    EXPECT_FALSE(integer("01"));
-    EXPECT_FALSE(integer("-0"));
-}
-
-TEST(ParserTest, DelimitedBy)
-{
-    auto token_parser = parse_n(parse_any_of("abcd"), 1, 2);
-    auto parser = parse_delimited_by(
-        token_parser, parse_literal(','), parse_literal(';'));
-
-    auto result = parser("a,bc,d;");
-    ASSERT_TRUE(result);
-    EXPECT_THAT(result.value(), ElementsAre("a", "bc", "d"));
-    EXPECT_EQ(result.input.front(), ';');
-}
-
-TEST(ParserTest, DelimitedByMultiple)
-{
-    auto token = parse_some(parse_any_of("abcde"));
-    auto delimiter = parse_ignoring_ws(parse_literal(','));
-    auto terminator = parse_literal(';');
-
-    auto parser = parse_delimited_by(token, delimiter, terminator);
-
-    auto result = parser("a ,bc, d,e;");
-    ASSERT_TRUE(result);
-    EXPECT_THAT(result.value(),
-                ElementsAre("a", "bc", "d", "e"));
-}
-
-// TEST(ParserTest, DelimitedByMultiple) {
-//     auto token_parser = parse_n(parse_any_of("abcde"),1,20).skip(parse_ws());
-//     auto delimiter = parse_literal(',').skip(parse_ws());
-//     auto parser = parse_delimited_by(
-//         token_parser, delimiter, parse_literal(';'));
-
-//     auto result = parser("a ,bc, d,e;");
-//     ASSERT_TRUE(result);
-//     EXPECT_THAT(result.value(),
-//         ElementsAre("a", "bc", "d", "e"));
-// }
-
-TEST(ParserTest, AnyOf)
-{
-    auto parser = parse_any_of("abc&!");
-
-    auto some = parse_some(parser);
-    auto result = some("!!cb&baa");
-
-    EXPECT_TRUE(result);
-    EXPECT_THAT(result.value(), Eq("!!cb&baa"));
-}
-
-TEST(ParserTest, ParseN)
-{
-    auto parser = parse_n(parse_any_of("abc"), 1, 2);
-    auto result = parser("ab");
-
-    EXPECT_TRUE(result);
-    EXPECT_THAT(result.value(), Eq("ab"));
-
-    result = parser("bd");
-    EXPECT_TRUE(result);
-    // EXPECT_STRV_EQ(result.value(), "b");
-    EXPECT_EQ(result.input.front(), 'd');
-}
-
-TEST(ParserTest, AndNot)
-{
-    auto parser = parse_n(
-        parse_range('a', 'z').and_not(parse_literal('x')), 4);
-
-    auto result = parser("abyz");
-    ASSERT_TRUE(result);
-
-    result = parser("uvxy");
-    ASSERT_FALSE(result);
-}
-
-TEST(ParserTest, RGB)
-{
-    auto hex = parse_str("0x").and_then(parsers::hexbyte);
-    auto delimiter = parse_ignoring_ws(parse_literal(','));
-    auto parser = parse_str("rgb")
-                      .skip(parse_ws(true))
-                      .and_then(parse_literal('('))
-                      .and_then(
-                          parse_delimited_by(hex, delimiter, parse_literal(')')))
-                      .skip(parse_literal(')'));
-
-    auto result = parser("rgb(0xFF, 0xA0, 0x45)");
-    EXPECT_TRUE(result);
-    EXPECT_EQ(result.value().size(), 3);
-    EXPECT_THAT(result.value(), ElementsAre(0xFF, 0xA0, 0x45));
-    EXPECT_TRUE(result.input.empty());
-}
-
-TEST(ParserTest, Spacing)
-{
-
-    auto dimension_parser = parsers::number().and_then([](auto value) { 
-        return parse_str("px").as(Dimension{
-            .value = value,
-            .units = Dimension::px
-        })
-        .or_else(parse_literal('%').as(Dimension{
-            .value = value,
-            .units = Dimension::pct
-        })); 
+Parser<int> number() {
+  auto positive_number = parse_digit(1, 9).and_then([](int val) {
+    return parse_some(parse_digit()).transform([val](std::vector<int> digits) {
+      int result = val;
+      for (auto d : digits) {
+        result = (result * 10) + d;
+      }
+      return result;
     });
+  });
 
-    auto spacing =
-        parse_delimited_by(dimension_parser, parse_ws(false), parse_literal(';'))
-            .transform([](const std::vector<Dimension> &values) -> Spacing {
+  auto zero = parse_digit(0, 0).and_not(parse_digit(0, 9));
+
+  auto integer = positive_number.or_else(zero).or_else(
+      parse_literal('-').and_then(positive_number).transform([](int val) {
+        return -val;
+      }));
+  return integer;
+}
+}  // namespace parsers
+// Demonstrate some basic assertions.
+TEST(ParserTest, ParseStringTest) {
+  auto parser = parse_str("hello");
+  auto result = parser("hello");
+
+  EXPECT_TRUE(result.has_value());
+  EXPECT_THAT(result.value(), Eq("hello"));
+}
+
+TEST(ParserTest, ParseHelloWorld) {
+  auto parser = parse_str("hello")
+                    .skip(parse_opt_ws())
+                    .and_then(parse_str(","))
+                    .skip(parse_opt_ws())
+                    .and_then(parse_str("world"));
+
+  auto result = parser("hello, world");
+  assert(result.value() == "world");
+
+  EXPECT_THAT(result.value(), Eq("world"));
+}
+
+TEST(ParserTest, ContainsStr) {
+  EXPECT_TRUE(detail::str_contains("hello", 'h'));
+  EXPECT_FALSE(detail::str_contains("hello", 'x'));
+}
+
+TEST(ParserTest, HexNumbers) {
+  auto lowercase = {"a", "b", "c", "d", "e", "f"};
+  int expected = 10;
+  for (auto input : lowercase) {
+    EXPECT_EQ(parsers::hexit(input).value(), expected);
+    ++expected;
+  }
+
+  auto uppercase = {"A", "B", "C", "D", "E", "F"};
+  expected = 10;
+  for (auto input : uppercase) {
+    EXPECT_EQ(parsers::hexit(input).value(), expected);
+    ++expected;
+  }
+
+  auto digits = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"};
+  expected = 0;
+  for (auto input : digits) {
+    EXPECT_EQ(parsers::hexit(input).value(), expected);
+    ++expected;
+  }
+
+  EXPECT_FALSE(parsers::hexit("q"));
+  EXPECT_FALSE(parsers::hexit("R"));
+
+  EXPECT_EQ(parsers::hexbyte("0F").value(), 0x0F);
+  EXPECT_EQ(parsers::hexbyte("AA").value(), 0xAA);
+  EXPECT_EQ(parsers::hexbyte("7F").value(), 0x7F);
+  EXPECT_EQ(parsers::hexbyte("80").value(), 0x80);
+
+  EXPECT_FALSE(parsers::hexbyte("G7"));
+  EXPECT_FALSE(parsers::hexbyte("-1"));
+}
+
+TEST(ParserTest, ParseDigit) {
+  auto digit = parse_digit();
+  EXPECT_TRUE(digit("0").value() == 0);
+  auto digit_with_range = parse_digit(2, 4);
+  EXPECT_FALSE(digit_with_range("1").has_value());
+  EXPECT_TRUE(digit_with_range("2").has_value());
+  EXPECT_TRUE(digit_with_range("3").has_value());
+  EXPECT_TRUE(digit_with_range("4").has_value());
+}
+
+TEST(ParserTest, ParseNumber) {
+  // These are complicated enough that they should probably go in the library
+  auto integer = parsers::number();
+
+  EXPECT_EQ(integer("0").value(), 0);
+  EXPECT_EQ(integer("123").value(), 123);
+  EXPECT_EQ(integer("-123").value(), -123);
+  EXPECT_FALSE(integer("01"));
+  EXPECT_FALSE(integer("-0"));
+}
+
+TEST(ParserTest, DelimitedBy) {
+  auto token_parser = parse_n(parse_any_of("abcd"), 1, 2);
+  auto parser =
+      parse_delimited_by(token_parser, parse_literal(','), parse_literal(';'));
+
+  auto result = parser("a,bc,d;");
+  ASSERT_TRUE(result);
+  EXPECT_THAT(result.value(), ElementsAre("a", "bc", "d"));
+  EXPECT_EQ(result.input.front(), ';');
+}
+
+TEST(ParserTest, DelimitedByMultiple) {
+  auto token = parse_some(parse_any_of("abcde"));
+  auto delimiter = parse_ignoring_ws(parse_literal(','));
+  auto terminator = parse_literal(';');
+
+  auto parser = parse_delimited_by(token, delimiter, terminator);
+
+  auto result = parser("a ,bc, d,e;");
+  ASSERT_TRUE(result);
+  EXPECT_THAT(result.value(), ElementsAre("a", "bc", "d", "e"));
+}
+
+TEST(ParserTest, AnyOf) {
+  auto parser = parse_any_of("abc&!");
+
+  auto some = parse_some(parser);
+  auto result = some("!!cb&baa");
+
+  EXPECT_TRUE(result);
+  EXPECT_THAT(result.value(), Eq("!!cb&baa"));
+}
+
+TEST(ParserTest, ParseN) {
+  auto parser = parse_n(parse_any_of("abc"), 1, 2);
+  auto result = parser("ab");
+
+  EXPECT_TRUE(result);
+  EXPECT_THAT(result.value(), Eq("ab"));
+
+  result = parser("bd");
+  EXPECT_TRUE(result);
+  // EXPECT_STRV_EQ(result.value(), "b");
+  EXPECT_EQ(result.input.front(), 'd');
+}
+
+TEST(ParserTest, AndNot) {
+  auto parser = parse_n(parse_range('a', 'z').and_not(parse_literal('x')), 4);
+
+  auto result = parser("abyz");
+  ASSERT_TRUE(result);
+
+  result = parser("uvxy");
+  ASSERT_FALSE(result);
+}
+
+TEST(ParserTest, RGB) {
+  auto hex = parse_str("0x").and_then(parsers::hexbyte);
+  auto delimiter = parse_ignoring_ws(parse_literal(','));
+  auto parser =
+      parse_str("rgb")
+          .skip(parse_opt_ws())
+          .and_then(parse_literal('('))
+          .and_then(parse_delimited_by(hex, delimiter, parse_literal(')')))
+          .skip(parse_literal(')'));
+
+  auto result = parser("rgb(0xFF, 0xA0, 0x45)");
+  EXPECT_TRUE(result);
+  EXPECT_EQ(result.value().size(), 3);
+  EXPECT_THAT(result.value(), ElementsAre(0xFF, 0xA0, 0x45));
+  EXPECT_TRUE(result.input.empty());
+}
+
+int decode_hex_str(std::string_view str) {
+  char buf[3] = {str[0], str[1], '\0'};
+  return (uint8_t)(std::strtoul(buf, nullptr, 16));
+}
+
+TEST(ParserTest, HexColor) {
+  auto is_hexit = [](char ch) {
+    ch = toupper(ch);
+    return (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'F');
+  };
+
+  auto parse_hex_digit(detail::parse_char_class(is_hexit));
+
+  auto hex_color_parser =
+      parse_literal('#')
+          .and_then(parse_n(parse_hex_digit, 6))
+          .transform([](std::string_view value) {
+            return Color{.r = decode_hex_str(value.substr(0, 2)),
+                         .g = decode_hex_str(value.substr(2, 4)),
+                         .b = decode_hex_str(value.substr(4, 6))};
+          });
+  //    EXPECT_TRUE(hex_color_parser("#004488;"));
+  auto result = hex_color_parser("#A87F01;");
+  Color c = result.value();
+  EXPECT_THAT(c.r, Eq(0xA8));
+  EXPECT_THAT(c.g, Eq(0x7F));
+  EXPECT_THAT(c.b, Eq(0x01));
+  EXPECT_THAT(result.input.front(), Eq(';'));
+}
+
+TEST(ParserTest, Spacing) {
+  auto dimension_parser = parsers::number().and_then([](auto value) {
+    return parse_str("px")
+        .as(Dimension{.value = value, .units = Dimension::px})
+        .or_else(parse_literal('%').as(
+            Dimension{.value = value, .units = Dimension::pct}));
+  });
+
+  auto spacing =
+      parse_delimited_by(dimension_parser, parse_ws(), parse_literal(';'))
+          .transform([](std::vector<Dimension> const& values) -> Spacing {
             Spacing sp;
-            dump_result(values);
-            std::cout << std::endl;
             switch (values.size()) {
-                case 1:
-                    sp.top = sp.right = sp.bottom = sp.left = values[0];
-                    return sp;
-                case 2:
-                    sp.top = sp.bottom = values[0];
-                    sp.right = sp.left = values[1];
-                    return sp;
-                case 3:
-                    sp.top = values[0];
-                    sp.left = sp.right  = values[1];
-                    sp.bottom = values[2];
-                    return sp;
-                case 4:
-                    sp.top = values[0];
-                    sp.right = values[1];
-                    sp.bottom = values[2];
-                    sp.left = values[3];
-                    return sp;
+              case 1:
+                sp.top = sp.right = sp.bottom = sp.left = values[0];
+                return sp;
+              case 2:
+                sp.top = sp.bottom = values[0];
+                sp.right = sp.left = values[1];
+                return sp;
+              case 3:
+                sp.top = values[0];
+                sp.left = sp.right = values[1];
+                sp.bottom = values[2];
+                return sp;
+              case 4:
+                sp.top = values[0];
+                sp.right = values[1];
+                sp.bottom = values[2];
+                sp.left = values[3];
+                return sp;
             }
-            return sp; });
-    auto result = spacing("10px 22px;");
-    ASSERT_TRUE(result);
-    EXPECT_TRUE(result.value().top.value == 10);
+            return sp;
+          });
+  auto result = spacing("10px 22px;");
+  ASSERT_TRUE(result);
+  EXPECT_TRUE(result.value().top.value == 10);
+  EXPECT_TRUE(result.value().right.value == 22);
+  EXPECT_THAT(result.input.front(), Eq(';'));
 }

--- a/styles.css
+++ b/styles.css
@@ -1,12 +1,12 @@
 .otherthing {
-    height : 20px;
-    width :  201px;
-    color : rgb(156, 39, 188);
+    height: 20px;
+    width:  201px;
+    color: rgb(156, 39, 188);
 }
 
 .something {
-    height : 10px;
+    height : 88%;
     width : 200px;
-    color : #004488;
-    padding: 10px 20px;
+    color: #01A87F;
+    padding: 10px 2px;
 }


### PR DESCRIPTION
Diff is pretty massive here because I added clang-format support...

Most substantive change is the explicity handling of white space.
- parse_ws to parse mandatory whitespace (eg. in a delimiter)
- parse_opt_ws to parse optional whitespace
- refactor char matchers
- re-use combinators when possible for parse_some and parse_n
