### PR TITLE
use trim operator and remove parse_ignoring_ws function

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,7 +123,7 @@ Parser<Color> parse_color() {
                          .b = decode_hex_str(value.substr(4, 6))};
           });
 
-  auto delimiter = parse_ignoring_ws(parse_literal(','));
+  auto delimiter = parse_literal(',').trim();
   auto rgb_parser =
       parse_str("rgb")
           .skip(parse_opt_ws())

--- a/src/parser.h
+++ b/src/parser.h
@@ -590,11 +590,6 @@ Parser<detail::discontinuous_string_view> parse_ignoring(
   return parse_ignoring(detail::to_discontinuous(parser), ignore);
 }
 
-Parser<detail::discontinuous_string_view> parse_ignoring_ws(
-    const StringParser& parser) {
-  return parse_ignoring(parser, parse_opt_ws());
-}
-
 template <typename T>
 Parser<T> parse_ref(const Parser<T>& parser) {
   return Parser<T>([&](std::string_view input) { return parser(input); });

--- a/src/test/mparse_test.cpp
+++ b/src/test/mparse_test.cpp
@@ -162,9 +162,9 @@ TEST(ParserTest, ParseNumber) {
 }
 
 TEST(ParserTest, Optional) {
-  auto opt_parser = parse_literal('*');
+  auto optional_star = parse_literal('*');
   auto parser =
-      parse_str("v").and_then(parse_opt(opt_parser)).and_then(parse_str("w"));
+      parse_str("v").and_then(parse_opt(optional_star)).and_then(parse_str("w"));
   EXPECT_TRUE(parser("v*w"));
   EXPECT_TRUE(parser("vw"));
 }
@@ -190,7 +190,7 @@ TEST(ParserTest, DelimitedBy) {
 
 TEST(ParserTest, DelimitedByMultiple) {
   auto token = parse_some(parse_any_of("abcde"));
-  auto delimiter = parse_ignoring_ws(parse_literal(','));
+  auto delimiter = parse_literal(',').trim();
   auto terminator = parse_literal(';');
 
   auto parser = parse_delimited_by(token, delimiter, terminator);
@@ -235,7 +235,7 @@ TEST(ParserTest, AndNot) {
 
 TEST(ParserTest, RGB) {
   auto hex = parse_str("0x").and_then(parsers::hexbyte);
-  auto delimiter = parse_ignoring_ws(parse_literal(','));
+  auto delimiter = parse_literal(',').trim();
   auto parser =
       parse_str("rgb")
           .skip(parse_opt_ws())


### PR DESCRIPTION
Now that we have trim we no longer need a separate function to ignore whitespace. This PR:

- removes parse_optional_ws
- replaces calls to parse_optional_ws with parser.trim()

